### PR TITLE
docs: FR #6 Vercel 部署配置文档

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,3 +240,11 @@ WORLDMONITOR_VALID_KEYS=
 # Convex deployment URL for email registration storage.
 # Set up at: https://dashboard.convex.dev/
 CONVEX_URL=
+
+
+# ------ IrishTech Daily Configuration ------
+
+# Site variant: set to "ireland" for IrishTech Daily
+# Default: "full" (worldmonitor.app)
+# Options: full | tech | finance | commodity | happy | ireland
+VITE_VARIANT=ireland


### PR DESCRIPTION
## 改动
- 在 .env.example 添加 Ireland variant 说明
- 文档化 VITE_VARIANT=ireland 配置

**部署步骤**：
1. 在 Vercel Dashboard 设置环境变量 `VITE_VARIANT=ireland`
2. 部署后自动使用 IrishTech Daily 配置

Closes #6