### PR TITLE
fix: reduce default zoom for mobile

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -516,7 +516,7 @@ export class PanelLayoutManager implements AppModule {
     
     // Ireland variant: zoom to Ireland by default (more zoomed out for context)
     const isIreland = SITE_VARIANT === 'ireland';
-    const defaultZoom = isIreland ? (this.ctx.isMobile ? 4.5 : 5.5) : (this.ctx.isMobile ? 2.5 : 1.0);
+    const defaultZoom = isIreland ? (this.ctx.isMobile ? 3.5 : 4.5) : (this.ctx.isMobile ? 2.5 : 1.0);
     const defaultPan = isIreland ? { x: 0, y: 0 } : { x: 0, y: 0 };
     const defaultView = isIreland ? 'eu' : (this.ctx.isMobile ? this.ctx.resolvedLocation : 'global');
     


### PR DESCRIPTION
移动端默认 zoom 太近，爱尔兰都看不全。

- 移动端: 4.5 → 3.5
- 桌面端: 5.5 → 4.5