### PR TITLE
fix: expand bounds and grey out UK

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5365,11 +5365,8 @@ export class DeckGLMap {
               'fill-color': '#888888',
               'fill-opacity': 0.4,
             },
-            // Filter: show grey for all countries EXCEPT Ireland (IE) and UK (GB for Northern Ireland context)
-            filter: ['all',
-              ['!=', ['get', 'ISO3166-1-Alpha-2'], 'IE'],
-              ['!=', ['get', 'ISO3166-1-Alpha-2'], 'GB'],
-            ],
+            // Filter: show grey for all countries EXCEPT Ireland (IE)
+            filter: ['!=', ['get', 'ISO3166-1-Alpha-2'], 'IE'],
           }, 'country-interactive'); // Insert below interactive layer
         }
 

--- a/src/config/variants/ireland.ts
+++ b/src/config/variants/ireland.ts
@@ -10,8 +10,8 @@ export * from './base';
 // SW corner: -15, 48 (includes more Atlantic)
 // NE corner: 2, 60 (includes UK mainland)
 export const IRELAND_BOUNDS = {
-  sw: { lng: -15, lat: 48 },
-  ne: { lng: 2, lat: 60 },
+  sw: { lng: -20, lat: 45 },
+  ne: { lng: 5, lat: 62 },
 } as const;
 
 // Minimum zoom level - lower = more zoomed out


### PR DESCRIPTION
1. 扩大边界让爱尔兰能完整显示
2. 英国也置灰（只有爱尔兰正常颜色）