### PR TITLE
feat: proper country fill for Ireland variant

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5314,13 +5314,17 @@ export class DeckGLMap {
           type: 'geojson',
           data: geojson,
         });
+        // For Ireland variant: fill non-Ireland countries with dark color
+        const isIrelandVariant = SITE_VARIANT === 'ireland';
         this.maplibreMap.addLayer({
           id: 'country-interactive',
           type: 'fill',
           source: 'country-boundaries',
           paint: {
-            'fill-color': '#3b82f6',
-            'fill-opacity': 0,
+            'fill-color': isIrelandVariant 
+              ? ['case', ['==', ['get', 'ISO3166-1-Alpha-2'], 'IE'], 'rgba(0,0,0,0)', '#1a1a1a']
+              : '#3b82f6',
+            'fill-opacity': isIrelandVariant ? 0.6 : 0,
           },
         });
         this.maplibreMap.addLayer({


### PR DESCRIPTION
用 MapLibre 表达式直接设置国家颜色：
- 爱尔兰：透明（显示底图）
- 其他国家：深灰色 60% 透明度