### PR TITLE
fix: load Ireland-specific feeds for ireland variant

### DIFF
--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -1172,6 +1172,9 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
 };
 
 // Variant-aware exports
+// Import Ireland feeds
+import { FEEDS as IRELAND_FEEDS } from './variants/ireland';
+
 export const FEEDS = SITE_VARIANT === 'tech'
   ? TECH_FEEDS
   : SITE_VARIANT === 'finance'
@@ -1180,7 +1183,9 @@ export const FEEDS = SITE_VARIANT === 'tech'
       ? HAPPY_FEEDS
       : SITE_VARIANT === 'commodity'
         ? COMMODITY_FEEDS
-        : FULL_FEEDS;
+        : SITE_VARIANT === 'ireland'
+          ? IRELAND_FEEDS
+          : FULL_FEEDS;
 
 export const SOURCE_REGION_MAP: Record<string, { labelKey: string; feedKeys: string[] }> = {
   // Full (geopolitical) variant regions


### PR DESCRIPTION
之前 FEEDS 导出没有处理 ireland case，导致用了 FULL_FEEDS 而不是爱尔兰专用的 feeds