### PR TITLE
fix: add ireland-monitor.vercel.app to trusted origins

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -8,6 +8,9 @@ const DESKTOP_ORIGIN_PATTERNS = [
 const BROWSER_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
   /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  // Ireland Monitor variant
+  /^https:\/\/ireland-monitor\.vercel\.app$/,
+  /^https:\/\/ireland-monitor-[a-z0-9-]+\.vercel\.app$/,
   ...(process.env.NODE_ENV === 'production' ? [] : [
     /^https?:\/\/localhost(:\d+)?$/,
     /^https?:\/\/127\.0\.0\.1(:\d+)?$/,


### PR DESCRIPTION
API 认证不再拒绝 ireland-monitor.vercel.app 的请求