### PR TITLE
fix: add ireland-monitor to CORS allowed origins

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,6 +1,9 @@
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
   /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  // Ireland Monitor variant
+  /^https:\/\/ireland-monitor\.vercel\.app$/,
+  /^https:\/\/ireland-monitor-[a-z0-9-]+\.vercel\.app$/,
   /^https?:\/\/localhost(:\d+)?$/,
   /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,


### PR DESCRIPTION
_cors.js 也需要允许 ireland-monitor.vercel.app