### PR TITLE
fix: add Ireland RSS domains to allowed list

### DIFF
--- a/api/_rss-allowed-domains.js
+++ b/api/_rss-allowed-domains.js
@@ -288,5 +288,22 @@ export default [
   "www.mining-technology.com",
   "www.australianmining.com.au",
   "news.goldseek.com",
-  "news.silverseek.com"
+  "news.silverseek.com",
+  // Ireland-specific feeds
+  "siliconrepublic.com",
+  "www.siliconrepublic.com",
+  "techcentral.ie",
+  "www.techcentral.ie",
+  "businessplus.ie",
+  "irishtechnews.ie",
+  "irishtimes.com",
+  "www.irishtimes.com",
+  "independent.ie",
+  "www.independent.ie",
+  "rte.ie",
+  "www.rte.ie",
+  "eu-startups.com",
+  "www.eu-startups.com",
+  "tech.eu",
+  "sifted.eu"
 ];


### PR DESCRIPTION
爱尔兰 RSS 源域名没有在允许列表，导致 403 Forbidden