### PR TITLE
fix: allow rss-proxy in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,7 @@ const SOCIAL_PREVIEW_UA =
 
 const SOCIAL_PREVIEW_PATHS = new Set(['/api/story', '/api/og-story']);
 
-const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health']);
+const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health', '/api/rss-proxy']);
 
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;


### PR DESCRIPTION
Middleware 的 bot/UA 检查阻止了 rss-proxy 请求