### PR TITLE
fix: use Ireland-specific map layers

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -823,6 +823,9 @@ export const DEFAULT_PANELS = SITE_VARIANT === 'happy'
         ? COMMODITY_PANELS
         : FULL_PANELS;
 
+// Import Ireland variant layers
+import { VARIANT_CONFIG as IRELAND_VARIANT_CONFIG } from './variants/ireland';
+
 export const DEFAULT_MAP_LAYERS = SITE_VARIANT === 'happy' 
   ? HAPPY_MAP_LAYERS 
   : SITE_VARIANT === 'tech' 
@@ -831,7 +834,9 @@ export const DEFAULT_MAP_LAYERS = SITE_VARIANT === 'happy'
       ? FINANCE_MAP_LAYERS 
       : SITE_VARIANT === 'commodity'
         ? COMMODITY_MAP_LAYERS
-        : FULL_MAP_LAYERS;
+        : SITE_VARIANT === 'ireland'
+          ? IRELAND_VARIANT_CONFIG.mapLayers
+          : FULL_MAP_LAYERS;
 
 export const MOBILE_DEFAULT_MAP_LAYERS = SITE_VARIANT === 'happy' 
   ? HAPPY_MOBILE_MAP_LAYERS 
@@ -841,7 +846,9 @@ export const MOBILE_DEFAULT_MAP_LAYERS = SITE_VARIANT === 'happy'
       ? FINANCE_MOBILE_MAP_LAYERS 
       : SITE_VARIANT === 'commodity'
         ? COMMODITY_MOBILE_MAP_LAYERS
-        : FULL_MOBILE_MAP_LAYERS;
+        : SITE_VARIANT === 'ireland'
+          ? IRELAND_VARIANT_CONFIG.mobileMapLayers
+          : FULL_MOBILE_MAP_LAYERS;
 
 /** Maps map-layer toggle keys to their data-freshness source IDs (single source of truth). */
 export const LAYER_TO_SOURCE: Partial<Record<keyof MapLayers, DataSourceId[]>> = {


### PR DESCRIPTION
Ireland variant 现在使用自己的 map layers 配置，去掉 Iran attacks、conflicts 等全球内容，只保留科技相关的 layers（datacenters, techHQs, startupHubs 等）