### PR TITLE
fix: hide irrelevant layers for Ireland variant

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -401,7 +401,10 @@ export class MapComponent {
     const happyLayers: (keyof MapLayers)[] = [
       'positiveEvents', 'kindness', 'happiness', 'speciesRecovery', 'renewableInstallations',
     ];
-    const layers = SITE_VARIANT === 'tech' ? techLayers : SITE_VARIANT === 'finance' ? financeLayers : SITE_VARIANT === 'happy' ? happyLayers : fullLayers;
+    const irelandLayers: (keyof MapLayers)[] = [
+      'datacenters', 'techHQs', 'startupHubs', 'cloudRegions', 'accelerators', 'techEvents',
+    ];
+    const layers = SITE_VARIANT === 'tech' ? techLayers : SITE_VARIANT === 'finance' ? financeLayers : SITE_VARIANT === 'happy' ? happyLayers : SITE_VARIANT === 'ireland' ? irelandLayers : fullLayers;
     const layerLabelKeys: Partial<Record<keyof MapLayers, string>> = {
       hotspots: 'components.deckgl.layers.intelHotspots',
       conflicts: 'components.deckgl.layers.conflictZones',


### PR DESCRIPTION
只显示爱尔兰相关的 layers：datacenters, techHQs, startupHubs 等。隐藏 Iran Attacks, Conflict Zones 等全球内容