### PR TITLE
fix: add ireland to MapVariant for DeckGLMap

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -3,7 +3,7 @@ import type { MapLayers } from '@/types';
 import { isDesktopRuntime } from '@/services/runtime';
 
 export type MapRenderer = 'flat' | 'globe';
-export type MapVariant = 'full' | 'tech' | 'finance' | 'happy' | 'commodity';
+export type MapVariant = 'full' | 'tech' | 'finance' | 'happy' | 'commodity' | 'ireland';
 
 const _desktop = isDesktopRuntime();
 
@@ -112,6 +112,10 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'minerals', 'pipelines', 'waterways', 'tradeRoutes',
     'ais', 'economic', 'fires', 'climate',
     'natural', 'weather', 'outages', 'dayNight',
+  ],
+  ireland: [
+    'datacenters', 'techHQs', 'startupHubs', 'cloudRegions',
+    'accelerators', 'techEvents',
   ],
 };
 


### PR DESCRIPTION
DeckGLMap 用 getLayersForVariant() 获取 layer 列表，ireland variant 之前不在配置里导致 fallback 到 full