### PR TITLE
feat: FR-52 alert keyword storage management

### DIFF
--- a/src/config/alert-presets.ts
+++ b/src/config/alert-presets.ts
@@ -1,0 +1,16 @@
+// Preset keywords optimized for Ireland tech monitoring workflows.
+export interface AlertPreset {
+  label: string;
+  keyword: string;
+}
+
+export const ALERT_PRESETS: AlertPreset[] = [
+  { label: 'Enterprise Ireland', keyword: 'Enterprise Ireland' },
+  { label: 'TCD Research', keyword: 'TCD' },
+  { label: 'UCD Research', keyword: 'UCD' },
+  { label: 'Funding Rounds', keyword: 'funding' },
+  { label: 'Dublin Tech Summit', keyword: 'Dublin Tech Summit' },
+  { label: 'SFI Grants', keyword: 'SFI' },
+  { label: 'Startups', keyword: 'startup' },
+  { label: 'M&A', keyword: 'acquisition' },
+];

--- a/src/services/alert-storage.ts
+++ b/src/services/alert-storage.ts
@@ -1,0 +1,129 @@
+import { ALERT_KEYWORD_LIMIT, DEFAULT_ALERT_PREFERENCE, type AlertKeyword, type AlertPreference } from '@/types/alert';
+
+const STORAGE_KEY = 'irishtech-alerts';
+
+function normalizeKeyword(keyword: string): string {
+  return keyword.trim().replace(/\s+/g, ' ');
+}
+
+function toKeywordKey(keyword: string): string {
+  return normalizeKeyword(keyword).toLowerCase();
+}
+
+function canUseLocalStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function safeRandomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `kw-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function parsePreference(raw: string | null): AlertPreference {
+  if (!raw) return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+  try {
+    const parsed = JSON.parse(raw) as Partial<AlertPreference>;
+    const keywords = Array.isArray(parsed.keywords)
+      ? parsed.keywords
+        .map((item) => {
+          const keyword = typeof item?.keyword === 'string' ? normalizeKeyword(item.keyword) : '';
+          if (!keyword) return null;
+          return {
+            id: typeof item.id === 'string' && item.id ? item.id : safeRandomId(),
+            keyword,
+            createdAt: typeof item.createdAt === 'string' && item.createdAt ? item.createdAt : new Date().toISOString(),
+            enabled: item.enabled !== false,
+          } as AlertKeyword;
+        })
+        .filter((item): item is AlertKeyword => !!item)
+      : [];
+
+    return {
+      keywords,
+      notifySound: parsed.notifySound !== false,
+      notifyBrowser: parsed.notifyBrowser !== false,
+    };
+  } catch {
+    return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+  }
+}
+
+export class AlertStorage {
+  public getPreferences(): AlertPreference {
+    if (!canUseLocalStorage()) {
+      return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+    }
+    return parsePreference(window.localStorage.getItem(STORAGE_KEY));
+  }
+
+  public getKeywords(): AlertKeyword[] {
+    return this.getPreferences().keywords;
+  }
+
+  public addKeyword(keyword: string): AlertKeyword {
+    const normalized = normalizeKeyword(keyword);
+    if (!normalized) {
+      throw new Error('关键词不能为空');
+    }
+
+    const current = this.getPreferences();
+    if (current.keywords.length >= ALERT_KEYWORD_LIMIT) {
+      throw new Error(`关键词最多 ${ALERT_KEYWORD_LIMIT} 个`);
+    }
+
+    const key = toKeywordKey(normalized);
+    const exists = current.keywords.some((item) => toKeywordKey(item.keyword) === key);
+    if (exists) {
+      throw new Error('关键词已存在');
+    }
+
+    const newKeyword: AlertKeyword = {
+      id: safeRandomId(),
+      keyword: normalized,
+      createdAt: new Date().toISOString(),
+      enabled: true,
+    };
+
+    this.save({ ...current, keywords: [...current.keywords, newKeyword] });
+    return newKeyword;
+  }
+
+  public removeKeyword(id: string): void {
+    const current = this.getPreferences();
+    const keywords = current.keywords.filter((item) => item.id !== id);
+    this.save({ ...current, keywords });
+  }
+
+  public toggleKeyword(id: string): AlertKeyword | null {
+    const current = this.getPreferences();
+    let updated: AlertKeyword | null = null;
+
+    const keywords = current.keywords.map((item) => {
+      if (item.id !== id) return item;
+      updated = { ...item, enabled: !item.enabled };
+      return updated;
+    });
+
+    if (!updated) return null;
+    this.save({ ...current, keywords });
+    return updated;
+  }
+
+  public setNotificationPreferences(partial: Pick<AlertPreference, 'notifySound' | 'notifyBrowser'>): void {
+    const current = this.getPreferences();
+    this.save({
+      ...current,
+      notifySound: partial.notifySound,
+      notifyBrowser: partial.notifyBrowser,
+    });
+  }
+
+  private save(preference: AlertPreference): void {
+    if (!canUseLocalStorage()) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preference));
+  }
+}
+
+export const alertStorage = new AlertStorage();

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -1,0 +1,22 @@
+// Alert keyword entity stored in localStorage.
+export interface AlertKeyword {
+  id: string;
+  keyword: string;
+  createdAt: string;
+  enabled: boolean;
+}
+
+// Alert preference payload persisted for client-side subscriptions.
+export interface AlertPreference {
+  keywords: AlertKeyword[];
+  notifySound: boolean;
+  notifyBrowser: boolean;
+}
+
+export const ALERT_KEYWORD_LIMIT = 20;
+
+export const DEFAULT_ALERT_PREFERENCE: AlertPreference = {
+  keywords: [],
+  notifySound: true,
+  notifyBrowser: true,
+};

--- a/tests/alert-storage.test.mts
+++ b/tests/alert-storage.test.mts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ALERT_KEYWORD_LIMIT } from '@/types/alert';
+import { AlertStorage } from '@/services/alert-storage';
+
+class MemoryStorage {
+  private readonly map = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+describe('alert-storage', () => {
+  let storage: MemoryStorage;
+  let service: AlertStorage;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    (globalThis as any).window = { localStorage: storage };
+    service = new AlertStorage();
+  });
+
+  it('add/get/remove keyword works', () => {
+    const first = service.addKeyword('Enterprise Ireland');
+    const second = service.addKeyword('TCD');
+    assert.equal(service.getKeywords().length, 2);
+
+    service.removeKeyword(first.id);
+    const keywords = service.getKeywords();
+    assert.equal(keywords.length, 1);
+    assert.equal(keywords[0]?.id, second.id);
+  });
+
+  it('toggle keyword enabled state', () => {
+    const item = service.addKeyword('funding');
+    const toggled = service.toggleKeyword(item.id);
+    assert.equal(toggled?.enabled, false);
+    assert.equal(service.getKeywords()[0]?.enabled, false);
+  });
+
+  it('prevents duplicate keyword ignoring case', () => {
+    service.addKeyword('Dublin Tech Summit');
+    assert.throws(() => service.addKeyword('dublin tech summit'), /已存在/);
+  });
+
+  it('enforces max keyword limit', () => {
+    for (let i = 0; i < ALERT_KEYWORD_LIMIT; i += 1) {
+      service.addKeyword(`kw-${i}`);
+    }
+    assert.throws(() => service.addKeyword('overflow'), /最多/);
+  });
+
+  it('recovers from invalid localStorage payload', () => {
+    storage.setItem('irishtech-alerts', '{invalid json');
+    const pref = service.getPreferences();
+    assert.equal(pref.keywords.length, 0);
+    assert.equal(pref.notifySound, true);
+    assert.equal(pref.notifyBrowser, true);
+  });
+
+  it('persists notify preferences', () => {
+    service.setNotificationPreferences({ notifySound: false, notifyBrowser: true });
+    const pref = service.getPreferences();
+    assert.equal(pref.notifySound, false);
+    assert.equal(pref.notifyBrowser, true);
+  });
+});


### PR DESCRIPTION
Implements FR #52 alert keyword subscription storage:\n\n- add alert types (AlertKeyword / AlertPreference)\n- add localStorage-backed AlertStorage service with CRUD\n- add keyword dedupe + max 20 limit + safe parse fallback\n- add Ireland-focused alert presets\n- add unit tests for persistence, toggle, dedupe, limit, and recovery\n\nCloses #52