### PR TITLE
feat: FR-54 add daily brief UI panel

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -16,7 +16,7 @@ import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } fro
 import { startLearning } from '@/services/country-instability';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
 import type { ParsedMapUrlState } from '@/utils';
-import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner, MarketTicker } from '@/components';
+import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner, MarketTicker, DailyBrief } from '@/components';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
@@ -72,6 +72,7 @@ export class App {
 
   private modules: { destroy(): void }[] = [];
   private marketTicker: MarketTicker | null = null;
+  private dailyBrief: DailyBrief | null = null;
   private unsubAiFlow: (() => void) | null = null;
   private visiblePanelPrimed = new Set<string>();
   private visiblePanelPrimeRaf: number | null = null;
@@ -568,6 +569,13 @@ export class App {
       this.marketTicker = new MarketTicker(tickerContainer, { symbols: ['BTC', 'ETH', 'NDX'] });
       this.marketTicker.mount();
     }
+
+    const briefContainer = document.getElementById('dailyBriefContainer');
+    const briefTrigger = document.getElementById('briefTriggerBtn');
+    if (briefContainer && briefTrigger) {
+      this.dailyBrief = new DailyBrief(briefContainer, briefTrigger);
+      this.dailyBrief.mount();
+    }
     showProBanner(this.state.container);
 
     const mobileGeoCoords = await geoCoordsPromise;
@@ -715,6 +723,8 @@ export class App {
     this.unsubAiFlow?.();
     this.marketTicker?.destroy();
     this.marketTicker = null;
+    this.dailyBrief?.destroy();
+    this.dailyBrief = null;
     this.state.breakingBanner?.destroy();
     destroyBreakingNewsAlerts();
     this.state.map?.destroy();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -255,6 +255,7 @@ export class PanelLayoutManager implements AppModule {
             </button>
             <div class="download-dropdown" id="downloadDropdown"></div>
           </div>`}
+          <button class="brief-btn" id="briefTriggerBtn">📰 TODAY'S BRIEF</button>
           <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
           ${this.ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
           ${this.ctx.isDesktopApp ? '' : `<button class="fullscreen-btn" id="fullscreenBtn" title="${t('header.fullscreen')}">⛶</button>`}
@@ -316,6 +317,7 @@ export class PanelLayoutManager implements AppModule {
         <div class="mobile-menu-version">v${__APP_VERSION__}</div>
       </nav>
       <div class="market-ticker-container" id="marketTickerContainer"></div>
+      <div class="daily-brief-container" id="dailyBriefContainer"></div>
       ${showRegionSelector ? this.renderRegionSheet() : ''}
       <div class="main-content">
         <div class="map-section" id="mapSection">

--- a/src/components/DailyBrief.ts
+++ b/src/components/DailyBrief.ts
@@ -1,0 +1,126 @@
+import { escapeHtml } from '@/utils/sanitize';
+
+export interface BriefResponse {
+  date?: string;
+  summary?: string;
+  sourceCount?: number;
+  generatedAt?: string;
+}
+
+export interface BriefViewModel {
+  dateLabel: string;
+  points: string[];
+  sourceCount: number;
+}
+
+export function parseBriefPoints(summary: string): string[] {
+  if (!summary) return [];
+
+  // 兼容 markdown 列表与纯文本段落。
+  const rows = summary
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/, '').trim())
+    .filter(Boolean);
+
+  return rows.slice(0, 5);
+}
+
+export function toBriefViewModel(payload: BriefResponse): BriefViewModel {
+  const dateLabel = payload.date || payload.generatedAt?.slice(0, 10) || new Date().toISOString().slice(0, 10);
+  const points = parseBriefPoints(payload.summary || '');
+  const sourceCount = Number.isFinite(payload.sourceCount) ? Number(payload.sourceCount) : 0;
+  return { dateLabel, points, sourceCount };
+}
+
+export class DailyBrief {
+  private readonly container: HTMLElement;
+  private readonly triggerButton: HTMLElement;
+  private readonly onBackdropClick: EventListener;
+  private readonly onOpenClick: EventListener;
+
+  constructor(container: HTMLElement, triggerButton: HTMLElement) {
+    this.container = container;
+    this.triggerButton = triggerButton;
+    this.onBackdropClick = (event: Event) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.id === 'dailyBriefOverlay' || target.id === 'dailyBriefCloseBtn') this.close();
+    };
+    this.onOpenClick = () => {
+      void this.open();
+    };
+  }
+
+  public mount(): void {
+    this.renderShell();
+    this.triggerButton.addEventListener('click', this.onOpenClick);
+    this.container.addEventListener('click', this.onBackdropClick);
+  }
+
+  public destroy(): void {
+    this.triggerButton.removeEventListener('click', this.onOpenClick);
+    this.container.removeEventListener('click', this.onBackdropClick);
+  }
+
+  public async open(): Promise<void> {
+    const overlay = this.container.querySelector<HTMLElement>('#dailyBriefOverlay');
+    const content = this.container.querySelector<HTMLElement>('#dailyBriefContent');
+    if (!overlay || !content) return;
+
+    overlay.classList.add('open');
+    content.innerHTML = '<div class="daily-brief-state">Loading today\'s highlights...</div>';
+    window.dispatchEvent(new CustomEvent('daily-brief:open'));
+
+    try {
+      const response = await fetch('/api/brief');
+      if (!response.ok) throw new Error(`HTTP_${response.status}`);
+      const payload = (await response.json()) as BriefResponse;
+      const vm = toBriefViewModel(payload);
+      content.innerHTML = this.renderBody(vm);
+    } catch {
+      content.innerHTML = `
+        <div class="daily-brief-state daily-brief-error">
+          Failed to load today's brief. <button id="dailyBriefRetryBtn" class="daily-brief-retry">Retry</button>
+        </div>
+      `;
+      this.container.querySelector('#dailyBriefRetryBtn')?.addEventListener('click', () => {
+        void this.open();
+      }, { once: true });
+    }
+  }
+
+  public close(): void {
+    const overlay = this.container.querySelector<HTMLElement>('#dailyBriefOverlay');
+    if (!overlay) return;
+    overlay.classList.remove('open');
+    window.dispatchEvent(new CustomEvent('daily-brief:close'));
+  }
+
+  private renderShell(): void {
+    this.container.innerHTML = `
+      <div class="daily-brief-overlay" id="dailyBriefOverlay" aria-hidden="true">
+        <section class="daily-brief-panel" role="dialog" aria-modal="true" aria-label="Today's Irish Tech Brief">
+          <header class="daily-brief-header">
+            <h2>📰 Today's Irish Tech Brief</h2>
+            <button id="dailyBriefCloseBtn" class="daily-brief-close" aria-label="Close">×</button>
+          </header>
+          <div id="dailyBriefContent" class="daily-brief-content"></div>
+        </section>
+      </div>
+    `;
+  }
+
+  private renderBody(vm: BriefViewModel): string {
+    const pointsHtml = vm.points.length > 0
+      ? `<ul class="daily-brief-points">${vm.points.map((p) => `<li>${escapeHtml(p)}</li>`).join('')}</ul>`
+      : '<div class="daily-brief-state">No highlights available for today.</div>';
+
+    return `
+      <div class="daily-brief-date">${escapeHtml(vm.dateLabel)}</div>
+      ${pointsHtml}
+      <div class="daily-brief-meta">Based on ${vm.sourceCount} sources</div>
+    `;
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -63,3 +63,4 @@ export * from './EscalationCorrelationPanel';
 export * from './EconomicCorrelationPanel';
 export * from './DisasterCorrelationPanel';
 export * from './MarketTicker';
+export * from './DailyBrief';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './styles/base-layer.css';
 import './styles/happy-theme.css';
 import './styles/market-ticker.css';
+import './styles/daily-brief.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import * as Sentry from '@sentry/browser';
 import { inject } from '@vercel/analytics';

--- a/src/styles/daily-brief.css
+++ b/src/styles/daily-brief.css
@@ -1,0 +1,128 @@
+.brief-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  background: rgba(14, 165, 233, 0.16);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.brief-btn:hover {
+  background: rgba(14, 165, 233, 0.28);
+}
+
+.daily-brief-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(2, 6, 23, 0.6);
+  z-index: 2000;
+}
+
+.daily-brief-overlay.open {
+  display: flex;
+}
+
+.daily-brief-panel {
+  width: min(720px, 100%);
+  max-height: min(80vh, 760px);
+  overflow-y: auto;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: var(--panel-bg, #0f172a);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+.daily-brief-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.daily-brief-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.daily-brief-close {
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 26px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.daily-brief-content {
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.daily-brief-date {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.daily-brief-points {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+}
+
+.daily-brief-points li {
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+
+.daily-brief-meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.daily-brief-state {
+  color: var(--text-secondary);
+}
+
+.daily-brief-retry {
+  margin-left: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 2px 8px;
+}
+
+@media (max-width: 768px) {
+  .brief-btn {
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+
+  .daily-brief-overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .daily-brief-panel {
+    width: 100%;
+    max-height: 86vh;
+    border-radius: 16px 16px 0 0;
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
+  }
+}

--- a/tests/daily-brief.test.mts
+++ b/tests/daily-brief.test.mts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseBriefPoints, toBriefViewModel } from '@/components/DailyBrief';
+
+describe('daily-brief helpers', () => {
+  it('parses markdown bullets and limits to 5 items', () => {
+    const summary = [
+      '- item 1',
+      '- item 2',
+      '- item 3',
+      '- item 4',
+      '- item 5',
+      '- item 6',
+    ].join('\n');
+
+    const points = parseBriefPoints(summary);
+    assert.equal(points.length, 5);
+    assert.equal(points[0], 'item 1');
+    assert.equal(points[4], 'item 5');
+  });
+
+  it('supports plain text rows', () => {
+    const points = parseBriefPoints('row a\nrow b');
+    assert.deepEqual(points, ['row a', 'row b']);
+  });
+
+  it('normalizes payload to stable view model', () => {
+    const vm = toBriefViewModel({
+      date: '2026-03-20',
+      summary: '- alpha\n- beta',
+      sourceCount: 7,
+    });
+
+    assert.equal(vm.dateLabel, '2026-03-20');
+    assert.equal(vm.sourceCount, 7);
+    assert.deepEqual(vm.points, ['alpha', 'beta']);
+  });
+});


### PR DESCRIPTION
Implements FR #54 Daily Brief UI panel:\n\n- add `TODAY'S BRIEF` trigger button in header\n- add `DailyBrief` modal component with loading / error / retry states\n- fetch and render brief data from `/api/brief`\n- support markdown-bullet/plain-text parsing with safe HTML escaping\n- add responsive styles for desktop/mobile\n- add unit tests for parsing and view-model normalization\n\nCloses #54