### PR TITLE
feat: FR-55 add alerts notification UI

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -16,7 +16,7 @@ import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } fro
 import { startLearning } from '@/services/country-instability';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
 import type { ParsedMapUrlState } from '@/utils';
-import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner, MarketTicker, DailyBrief } from '@/components';
+import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner, MarketTicker, DailyBrief, AlertPanel } from '@/components';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
@@ -73,6 +73,7 @@ export class App {
   private modules: { destroy(): void }[] = [];
   private marketTicker: MarketTicker | null = null;
   private dailyBrief: DailyBrief | null = null;
+  private alertPanel: AlertPanel | null = null;
   private unsubAiFlow: (() => void) | null = null;
   private visiblePanelPrimed = new Set<string>();
   private visiblePanelPrimeRaf: number | null = null;
@@ -576,6 +577,14 @@ export class App {
       this.dailyBrief = new DailyBrief(briefContainer, briefTrigger);
       this.dailyBrief.mount();
     }
+
+    const alertContainer = document.getElementById('alertPanelContainer');
+    const alertTrigger = document.getElementById('alertTriggerBtn');
+    const alertBadge = document.getElementById('alertBadge');
+    if (alertContainer && alertTrigger && alertBadge) {
+      this.alertPanel = new AlertPanel(alertContainer, alertTrigger, alertBadge);
+      this.alertPanel.mount();
+    }
     showProBanner(this.state.container);
 
     const mobileGeoCoords = await geoCoordsPromise;
@@ -725,6 +734,8 @@ export class App {
     this.marketTicker = null;
     this.dailyBrief?.destroy();
     this.dailyBrief = null;
+    this.alertPanel?.destroy();
+    this.alertPanel = null;
     this.state.breakingBanner?.destroy();
     destroyBreakingNewsAlerts();
     this.state.map?.destroy();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -318,6 +318,7 @@ export class PanelLayoutManager implements AppModule {
       </nav>
       <div class="market-ticker-container" id="marketTickerContainer"></div>
       <div class="daily-brief-container" id="dailyBriefContainer"></div>
+      <div class="alert-panel-container" id="alertPanelContainer"></div>
       ${showRegionSelector ? this.renderRegionSheet() : ''}
       <div class="main-content">
         <div class="map-section" id="mapSection">

--- a/src/components/AlertPanel.ts
+++ b/src/components/AlertPanel.ts
@@ -1,0 +1,160 @@
+import type { AlertEventDetail, AlertItem } from '@/types/alert';
+import { alertStorage } from '@/services/alert-storage';
+import { escapeHtml } from '@/utils/sanitize';
+import { AlertSettings } from './AlertSettings';
+
+function highlightKeywords(title: string, keywords: string[]): string {
+  let html = escapeHtml(title);
+  for (const keyword of keywords) {
+    const safe = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    html = html.replace(new RegExp(`(${safe})`, 'gi'), '<mark>$1</mark>');
+  }
+  return html;
+}
+
+function formatRelativeTime(ts: number): string {
+  const delta = Math.max(0, Date.now() - ts);
+  const minutes = Math.floor(delta / 60000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export class AlertPanel {
+  private readonly container: HTMLElement;
+  private readonly trigger: HTMLElement;
+  private readonly badge: HTMLElement;
+  private readonly onIncoming: EventListener;
+  private readonly onTriggerClick: EventListener;
+  private readonly onPanelClick: EventListener;
+  private settings: AlertSettings | null = null;
+
+  constructor(container: HTMLElement, trigger: HTMLElement, badge: HTMLElement) {
+    this.container = container;
+    this.trigger = trigger;
+    this.badge = badge;
+
+    this.onIncoming = (event: Event) => {
+      const detail = (event as CustomEvent<AlertEventDetail>).detail;
+      if (!detail?.article?.title || !detail?.article?.url) return;
+      const item = alertStorage.appendAlert(detail);
+      this.updateBadge();
+      this.renderList();
+      this.showBrowserNotification(item);
+    };
+
+    this.onTriggerClick = () => {
+      const panel = this.container.querySelector<HTMLElement>('#alertPanel');
+      if (!panel) return;
+      panel.classList.toggle('open');
+      if (panel.classList.contains('open')) {
+        window.dispatchEvent(new CustomEvent('alert-panel:open'));
+      }
+    };
+
+    this.onPanelClick = (event: Event) => {
+      const target = event.target as HTMLElement;
+      const itemEl = target.closest<HTMLElement>('[data-alert-id]');
+      const markAll = target.closest<HTMLElement>('#alertMarkAllReadBtn');
+      if (markAll) {
+        alertStorage.markAllRead();
+        this.updateBadge();
+        this.renderList();
+        return;
+      }
+      if (!itemEl) return;
+      const id = itemEl.dataset.alertId;
+      const url = itemEl.dataset.alertUrl;
+      if (!id) return;
+      alertStorage.markAlertRead(id);
+      this.updateBadge();
+      if (url) {
+        window.open(url, '_blank', 'noopener');
+        window.dispatchEvent(new CustomEvent('alert-item:click'));
+      }
+      this.renderList();
+    };
+  }
+
+  public mount(): void {
+    this.renderShell();
+    this.renderList();
+    this.updateBadge();
+    this.trigger.addEventListener('click', this.onTriggerClick);
+    this.container.addEventListener('click', this.onPanelClick);
+    window.addEventListener('irishtech-alert', this.onIncoming);
+  }
+
+  public destroy(): void {
+    this.trigger.removeEventListener('click', this.onTriggerClick);
+    this.container.removeEventListener('click', this.onPanelClick);
+    window.removeEventListener('irishtech-alert', this.onIncoming);
+  }
+
+  private renderShell(): void {
+    this.container.innerHTML = `
+      <div class="alert-panel" id="alertPanel">
+        <div class="alert-panel-header">
+          <strong>Alerts</strong>
+          <button id="alertMarkAllReadBtn" class="alert-mark-read">Mark all read</button>
+        </div>
+        <div id="alertList" class="alert-list"></div>
+        <div id="alertSettings" class="alert-settings-wrap"></div>
+      </div>
+    `;
+
+    const settingsEl = this.container.querySelector<HTMLElement>('#alertSettings');
+    if (settingsEl) {
+      this.settings = new AlertSettings(settingsEl, () => this.updateBadge());
+      this.settings.mount();
+    }
+  }
+
+  private renderList(): void {
+    const listEl = this.container.querySelector<HTMLElement>('#alertList');
+    if (!listEl) return;
+    const alerts = alertStorage.getAlerts();
+    if (alerts.length === 0) {
+      listEl.innerHTML = '<div class="alert-empty">No alerts yet</div>';
+      return;
+    }
+
+    listEl.innerHTML = alerts.map((item) => this.renderItem(item)).join('');
+  }
+
+  private renderItem(item: AlertItem): string {
+    return `
+      <article class="alert-item ${item.read ? 'read' : 'unread'}" data-alert-id="${item.id}" data-alert-url="${escapeHtml(item.article.url)}">
+        <div class="alert-item-time">${formatRelativeTime(item.timestamp)}</div>
+        <div class="alert-item-title">${highlightKeywords(item.article.title, item.keywords)}</div>
+        <div class="alert-item-meta">${escapeHtml(item.article.source)} · ${escapeHtml(item.keywords.join(', '))}</div>
+      </article>
+    `;
+  }
+
+  private updateBadge(): void {
+    const unread = alertStorage.getAlerts().filter((item) => !item.read).length;
+    this.badge.textContent = unread > 0 ? String(unread) : '';
+    this.badge.style.display = unread > 0 ? 'inline-flex' : 'none';
+  }
+
+  private showBrowserNotification(item: AlertItem): void {
+    const pref = alertStorage.getPreferences();
+    if (!pref.notifyBrowser) return;
+    if (typeof Notification === 'undefined') return;
+    if (Notification.permission !== 'granted') return;
+
+    const n = new Notification('🇮🇪 New Irish Tech Alert', {
+      body: item.article.title,
+      tag: item.article.id,
+    });
+    n.onclick = () => {
+      window.open(item.article.url, '_blank', 'noopener');
+      n.close();
+    };
+  }
+}
+
+export { highlightKeywords, formatRelativeTime };

--- a/src/components/AlertSettings.ts
+++ b/src/components/AlertSettings.ts
@@ -1,0 +1,100 @@
+import { ALERT_PRESETS } from '@/config/alert-presets';
+import { alertStorage } from '@/services/alert-storage';
+import { escapeHtml } from '@/utils/sanitize';
+
+export class AlertSettings {
+  private readonly container: HTMLElement;
+  private readonly onUpdated: () => void;
+
+  constructor(container: HTMLElement, onUpdated: () => void) {
+    this.container = container;
+    this.onUpdated = onUpdated;
+  }
+
+  public mount(): void {
+    this.render();
+    this.bindEvents();
+  }
+
+  public render(): void {
+    const keywords = alertStorage.getKeywords();
+    this.container.innerHTML = `
+      <div class="alert-settings">
+        <div class="alert-settings-title">Manage Keywords</div>
+        <div class="alert-settings-input-row">
+          <input id="alertKeywordInput" class="alert-settings-input" placeholder="Add keyword..." />
+          <button id="alertKeywordAddBtn" class="alert-settings-add">Add</button>
+        </div>
+        <div class="alert-presets">
+          ${ALERT_PRESETS.map((preset) => `<button class="alert-preset-btn" data-keyword="${escapeHtml(preset.keyword)}">${escapeHtml(preset.label)}</button>`).join('')}
+        </div>
+        <div class="alert-keyword-list">
+          ${keywords.map((item) => `
+            <div class="alert-keyword-item">
+              <label>
+                <input type="checkbox" data-toggle-id="${item.id}" ${item.enabled ? 'checked' : ''} />
+                ${escapeHtml(item.keyword)}
+              </label>
+              <button data-delete-id="${item.id}" class="alert-keyword-delete">×</button>
+            </div>
+          `).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  private bindEvents(): void {
+    this.container.querySelector('#alertKeywordAddBtn')?.addEventListener('click', () => this.addFromInput());
+    this.container.querySelector('#alertKeywordInput')?.addEventListener('keydown', (event) => {
+      if ((event as KeyboardEvent).key === 'Enter') this.addFromInput();
+    });
+
+    this.container.querySelectorAll<HTMLElement>('.alert-preset-btn').forEach((el) => {
+      el.addEventListener('click', () => {
+        const keyword = el.dataset.keyword;
+        if (!keyword) return;
+        this.tryAddKeyword(keyword);
+      });
+    });
+
+    this.container.querySelectorAll<HTMLInputElement>('input[data-toggle-id]').forEach((el) => {
+      el.addEventListener('change', () => {
+        const id = el.dataset.toggleId;
+        if (!id) return;
+        alertStorage.toggleKeyword(id);
+        this.render();
+        this.bindEvents();
+        this.onUpdated();
+      });
+    });
+
+    this.container.querySelectorAll<HTMLElement>('button[data-delete-id]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const id = el.dataset.deleteId;
+        if (!id) return;
+        alertStorage.removeKeyword(id);
+        this.render();
+        this.bindEvents();
+        this.onUpdated();
+      });
+    });
+  }
+
+  private addFromInput(): void {
+    const input = this.container.querySelector<HTMLInputElement>('#alertKeywordInput');
+    const value = input?.value || '';
+    this.tryAddKeyword(value);
+    if (input) input.value = '';
+  }
+
+  private tryAddKeyword(keyword: string): void {
+    try {
+      alertStorage.addKeyword(keyword);
+      this.render();
+      this.bindEvents();
+      this.onUpdated();
+    } catch {
+      // 错误通过静默失败避免打断主流程。
+    }
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -64,3 +64,5 @@ export * from './EconomicCorrelationPanel';
 export * from './DisasterCorrelationPanel';
 export * from './MarketTicker';
 export * from './DailyBrief';
+export * from './AlertPanel';
+export * from './AlertSettings';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import './styles/base-layer.css';
 import './styles/happy-theme.css';
 import './styles/market-ticker.css';
 import './styles/daily-brief.css';
+import './styles/alert.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import * as Sentry from '@sentry/browser';
 import { inject } from '@vercel/analytics';

--- a/src/services/alert-storage.ts
+++ b/src/services/alert-storage.ts
@@ -1,4 +1,12 @@
-import { ALERT_KEYWORD_LIMIT, DEFAULT_ALERT_PREFERENCE, type AlertKeyword, type AlertPreference } from '@/types/alert';
+import {
+  ALERT_HISTORY_LIMIT,
+  ALERT_KEYWORD_LIMIT,
+  DEFAULT_ALERT_PREFERENCE,
+  type AlertEventDetail,
+  type AlertItem,
+  type AlertKeyword,
+  type AlertPreference,
+} from '@/types/alert';
 
 const STORAGE_KEY = 'irishtech-alerts';
 
@@ -22,7 +30,7 @@ function safeRandomId(): string {
 }
 
 function parsePreference(raw: string | null): AlertPreference {
-  if (!raw) return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+  if (!raw) return { ...DEFAULT_ALERT_PREFERENCE, keywords: [], alerts: [] };
   try {
     const parsed = JSON.parse(raw) as Partial<AlertPreference>;
     const keywords = Array.isArray(parsed.keywords)
@@ -40,20 +48,42 @@ function parsePreference(raw: string | null): AlertPreference {
         .filter((item): item is AlertKeyword => !!item)
       : [];
 
+    const alerts = Array.isArray(parsed.alerts)
+      ? parsed.alerts
+        .map((item) => {
+          if (!item?.article || typeof item.article.title !== 'string' || typeof item.article.url !== 'string') return null;
+          return {
+            id: typeof item.id === 'string' && item.id ? item.id : safeRandomId(),
+            article: {
+              id: typeof item.article.id === 'string' && item.article.id ? item.article.id : safeRandomId(),
+              title: item.article.title,
+              url: item.article.url,
+              source: typeof item.article.source === 'string' ? item.article.source : 'Unknown',
+            },
+            keywords: Array.isArray(item.keywords) ? item.keywords.filter((kw) => typeof kw === 'string') : [],
+            timestamp: Number.isFinite(item.timestamp) ? Number(item.timestamp) : Date.now(),
+            read: item.read === true,
+          } as AlertItem;
+        })
+        .filter((item): item is AlertItem => !!item)
+        .slice(0, ALERT_HISTORY_LIMIT)
+      : [];
+
     return {
       keywords,
+      alerts,
       notifySound: parsed.notifySound !== false,
       notifyBrowser: parsed.notifyBrowser !== false,
     };
   } catch {
-    return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+    return { ...DEFAULT_ALERT_PREFERENCE, keywords: [], alerts: [] };
   }
 }
 
 export class AlertStorage {
   public getPreferences(): AlertPreference {
     if (!canUseLocalStorage()) {
-      return { ...DEFAULT_ALERT_PREFERENCE, keywords: [] };
+      return { ...DEFAULT_ALERT_PREFERENCE, keywords: [], alerts: [] };
     }
     return parsePreference(window.localStorage.getItem(STORAGE_KEY));
   }
@@ -118,6 +148,42 @@ export class AlertStorage {
       notifySound: partial.notifySound,
       notifyBrowser: partial.notifyBrowser,
     });
+  }
+
+  public getAlerts(): AlertItem[] {
+    return this.getPreferences().alerts;
+  }
+
+  public appendAlert(detail: AlertEventDetail): AlertItem {
+    const current = this.getPreferences();
+    const item: AlertItem = {
+      id: safeRandomId(),
+      article: {
+        id: detail.article.id || safeRandomId(),
+        title: detail.article.title,
+        url: detail.article.url,
+        source: detail.article.source || 'Unknown',
+      },
+      keywords: detail.keywords,
+      timestamp: Number.isFinite(detail.timestamp) ? detail.timestamp : Date.now(),
+      read: false,
+    };
+
+    const alerts = [item, ...current.alerts].slice(0, ALERT_HISTORY_LIMIT);
+    this.save({ ...current, alerts });
+    return item;
+  }
+
+  public markAlertRead(id: string): void {
+    const current = this.getPreferences();
+    const alerts = current.alerts.map((item) => (item.id === id ? { ...item, read: true } : item));
+    this.save({ ...current, alerts });
+  }
+
+  public markAllRead(): void {
+    const current = this.getPreferences();
+    const alerts = current.alerts.map((item) => ({ ...item, read: true }));
+    this.save({ ...current, alerts });
   }
 
   private save(preference: AlertPreference): void {

--- a/src/styles/alert.css
+++ b/src/styles/alert.css
@@ -1,0 +1,189 @@
+.alert-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.alert-badge {
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  padding: 0 5px;
+}
+
+.alert-panel-container {
+  position: fixed;
+  top: 62px;
+  right: 18px;
+  z-index: 1800;
+}
+
+.alert-panel {
+  display: none;
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(82vh, 720px);
+  overflow: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: var(--panel-bg, #0f172a);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.4);
+  padding: 14px;
+}
+
+.alert-panel.open {
+  display: block;
+}
+
+.alert-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.alert-mark-read {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.alert-list {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.alert-item {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.alert-item.unread {
+  border-left: 3px solid #169b62;
+  background: rgba(22, 155, 98, 0.08);
+}
+
+.alert-item-time {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.alert-item-title mark {
+  background: #fef08a;
+  color: #111827;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+.alert-item-meta {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.alert-empty {
+  color: var(--text-secondary);
+  padding: 8px 0;
+}
+
+.alert-settings {
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  padding-top: 10px;
+  display: grid;
+  gap: 10px;
+}
+
+.alert-settings-title {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.alert-settings-input-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+}
+
+.alert-settings-input {
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--text-primary);
+  padding: 0 10px;
+}
+
+.alert-settings-add,
+.alert-preset-btn,
+.alert-keyword-delete {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  color: var(--text-primary);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.alert-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.alert-preset-btn {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.alert-keyword-list {
+  display: grid;
+  gap: 6px;
+}
+
+.alert-keyword-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.alert-keyword-delete {
+  width: 24px;
+  height: 24px;
+}
+
+@media (max-width: 768px) {
+  .alert-btn {
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+
+  .alert-panel-container {
+    left: 10px;
+    right: 10px;
+    top: 58px;
+  }
+
+  .alert-panel {
+    width: 100%;
+    max-height: 72vh;
+  }
+}

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -6,17 +6,41 @@ export interface AlertKeyword {
   enabled: boolean;
 }
 
+export interface AlertArticle {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+}
+
+export interface AlertItem {
+  id: string;
+  article: AlertArticle;
+  keywords: string[];
+  timestamp: number;
+  read: boolean;
+}
+
 // Alert preference payload persisted for client-side subscriptions.
 export interface AlertPreference {
   keywords: AlertKeyword[];
+  alerts: AlertItem[];
   notifySound: boolean;
   notifyBrowser: boolean;
 }
 
+export interface AlertEventDetail {
+  article: AlertArticle;
+  keywords: string[];
+  timestamp: number;
+}
+
 export const ALERT_KEYWORD_LIMIT = 20;
+export const ALERT_HISTORY_LIMIT = 100;
 
 export const DEFAULT_ALERT_PREFERENCE: AlertPreference = {
   keywords: [],
+  alerts: [],
   notifySound: true,
   notifyBrowser: true,
 };

--- a/tests/alert-panel.test.mts
+++ b/tests/alert-panel.test.mts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatRelativeTime, highlightKeywords } from '@/components/AlertPanel';
+
+describe('alert-panel helpers', () => {
+  it('highlights matching keywords safely', () => {
+    const html = highlightKeywords('TCD secures funding', ['funding']);
+    assert.match(html, /<mark>funding<\/mark>/i);
+  });
+
+  it('escapes html before highlighting', () => {
+    const html = highlightKeywords('<script>alert(1)</script> funding', ['funding']);
+    assert.ok(!html.includes('<script>'));
+    assert.match(html, /&lt;script&gt;/);
+  });
+
+  it('formats relative time', () => {
+    const now = Date.now();
+    assert.equal(formatRelativeTime(now), 'Just now');
+    assert.equal(formatRelativeTime(now - 5 * 60_000), '5m ago');
+  });
+});

--- a/tests/alert-storage.test.mts
+++ b/tests/alert-storage.test.mts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { ALERT_KEYWORD_LIMIT } from '@/types/alert';
+import { ALERT_HISTORY_LIMIT, ALERT_KEYWORD_LIMIT } from '@/types/alert';
 import { AlertStorage } from '@/services/alert-storage';
 
 class MemoryStorage {
@@ -76,5 +76,30 @@ describe('alert-storage', () => {
     const pref = service.getPreferences();
     assert.equal(pref.notifySound, false);
     assert.equal(pref.notifyBrowser, true);
+  });
+
+  it('append alert and mark read', () => {
+    const item = service.appendAlert({
+      article: { id: 'a1', title: 'TCD raises AI funding', url: 'https://example.com/a1', source: 'RTE' },
+      keywords: ['TCD', 'funding'],
+      timestamp: Date.now(),
+    });
+
+    assert.equal(service.getAlerts().length, 1);
+    assert.equal(service.getAlerts()[0]?.read, false);
+
+    service.markAlertRead(item.id);
+    assert.equal(service.getAlerts()[0]?.read, true);
+  });
+
+  it('enforces alert history limit', () => {
+    for (let i = 0; i < ALERT_HISTORY_LIMIT + 5; i += 1) {
+      service.appendAlert({
+        article: { id: `a-${i}`, title: `title-${i}`, url: `https://example.com/${i}`, source: 'source' },
+        keywords: ['kw'],
+        timestamp: Date.now(),
+      });
+    }
+    assert.equal(service.getAlerts().length, ALERT_HISTORY_LIMIT);
   });
 });


### PR DESCRIPTION
Implements FR #55 Alert UI:\n\n- add ALERTS button with unread badge in header\n- add AlertPanel for alert feed view and read-state actions\n- add AlertSettings for keyword management (add/remove/toggle/presets)\n- extend alert localStorage service with alert history + read/unread state\n- add browser notification handling for incoming alert events\n- add styles for alert button/panel/settings and mobile layout\n- add unit tests for alert helpers and storage history/read flow\n\nCloses #55