### PR TITLE
feat(FR #69): disable market ticker for ireland variant

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -566,10 +566,13 @@ export class App {
 
     // Phase 1: Layout (creates map + panels — they'll find hydrated data)
     this.panelLayout.init();
-    const tickerContainer = document.getElementById('marketTickerContainer');
-    if (tickerContainer) {
-      this.marketTicker = new MarketTicker(tickerContainer, { symbols: ['BTC', 'ETH', 'NDX'] });
-      this.marketTicker.mount();
+    // Market ticker disabled for ireland variant (IrishTech Daily focuses on local tech news)
+    if (SITE_VARIANT !== 'ireland') {
+      const tickerContainer = document.getElementById('marketTickerContainer');
+      if (tickerContainer) {
+        this.marketTicker = new MarketTicker(tickerContainer, { symbols: ['BTC', 'ETH', 'NDX'] });
+        this.marketTicker.mount();
+      }
     }
 
     const briefContainer = document.getElementById('dailyBriefContainer');

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -317,7 +317,7 @@ export class PanelLayoutManager implements AppModule {
         </div>
         <div class="mobile-menu-version">v${__APP_VERSION__}</div>
       </nav>
-      <div class="market-ticker-container" id="marketTickerContainer"></div>
+      ${SITE_VARIANT !== 'ireland' ? '<div class="market-ticker-container" id="marketTickerContainer"></div>' : ''}
       <div class="daily-brief-container" id="dailyBriefContainer"></div>
       <div class="alert-panel-container" id="alertPanelContainer"></div>
       ${showRegionSelector ? this.renderRegionSheet() : ''}


### PR DESCRIPTION
## Summary

Disable global market data ticker (BTC/ETH/NASDAQ) for IrishTech Daily variant.

### Changes

- **App.ts**: Skip MarketTicker initialization when `SITE_VARIANT === 'ireland'`
- **panel-layout.ts**: Conditionally exclude `marketTickerContainer` div

### Rationale

IrishTech Daily focuses on Irish tech news and ecosystem. Global crypto/stock tickers:
1. Don't align with product positioning
2. Add unnecessary API calls
3. Waste valuable header space

### Testing

- All 1807 unit tests pass
- Typecheck passes
- Other variants (full, finance, tech) still have market ticker

Closes #69