### PR TITLE
feat(FR #70): enhance semiconductor news priority detection

### DIFF
--- a/src/services/news-priority.ts
+++ b/src/services/news-priority.ts
@@ -55,6 +55,21 @@ const P0_KEYWORDS = [
 ];
 
 /**
+ * P0 keywords for semiconductor industry (major investments, fab expansion)
+ * These require higher thresholds due to industry significance
+ */
+const SEMICONDUCTOR_P0_KEYWORDS = [
+  'fab expansion',
+  'chip plant',
+  'wafer fab',
+  'eu chips act grant',
+  'chips act ireland',
+  'chips act allocation',
+  'billion semiconductor',
+  'billion chip',
+];
+
+/**
  * P1 keywords - high priority (research, summits, big tech)
  */
 const P1_KEYWORDS = [
@@ -88,6 +103,30 @@ const P1_KEYWORDS = [
 ];
 
 /**
+ * Check if article mentions large semiconductor investment (€500M+ or €1B+)
+ */
+function hasSemiconductorInvestment(text: string): boolean {
+  // Check for Intel/semiconductor investment with large amounts
+  const hasIntelOrChip = /intel|semiconductor|chip|fab/i.test(text);
+  if (!hasIntelOrChip) return false;
+
+  // Match €X billion/bn/b or €X million/m
+  const billionMatch = text.match(/€\s*(\d+(?:\.\d+)?)\s*(?:billion|bn|b)\b/i);
+  if (billionMatch && billionMatch[1]) {
+    const amount = parseFloat(billionMatch[1]);
+    if (amount >= 1) return true; // €1B+
+  }
+
+  const millionMatch = text.match(/€\s*(\d+(?:\.\d+)?)\s*(?:million|m)\b/i);
+  if (millionMatch && millionMatch[1]) {
+    const amount = parseFloat(millionMatch[1]);
+    if (amount >= 500) return true; // €500M+
+  }
+
+  return false;
+}
+
+/**
  * Determine the priority of a news article based on keywords
  *
  * @param article - The news article to evaluate
@@ -98,6 +137,16 @@ export function getNewsPriority(article: NewsItem): NewsPriority {
 
   // Check P0 keywords first (highest priority)
   if (P0_KEYWORDS.some((kw) => text.includes(kw))) {
+    return NewsPriority.P0;
+  }
+
+  // Check semiconductor P0 keywords (fab expansion, EU Chips Act grants)
+  if (SEMICONDUCTOR_P0_KEYWORDS.some((kw) => text.includes(kw))) {
+    return NewsPriority.P0;
+  }
+
+  // Check for large semiconductor investment (€500M+ or €1B+)
+  if (hasSemiconductorInvestment(text)) {
     return NewsPriority.P0;
   }
 
@@ -126,6 +175,25 @@ export function getPriorityScore(article: NewsItem): number {
     score += 1000;
   } else if (priority === NewsPriority.P1) {
     score += 500;
+  }
+
+  // ====== Semiconductor company boost ======
+  if (text.includes('intel ireland') || text.includes('intel leixlip')) {
+    score += 200;
+  }
+  if (text.includes('analog devices')) {
+    score += 150;
+  }
+  if (text.includes('eu chips act')) {
+    score += 180;
+  }
+
+  // ====== Investment amount boost ======
+  // Bonus for billions (€Xbn)
+  const billionMatch = text.match(/€\s*(\d+(?:\.\d+)?)\s*(?:billion|bn|b)\b/i);
+  if (billionMatch && billionMatch[1]) {
+    const billions = parseFloat(billionMatch[1]);
+    score += billions * 100; // €1B = +100 points
   }
 
   // Bonus for funding amounts (€Xm or $Xm)

--- a/tests/news-priority.test.mts
+++ b/tests/news-priority.test.mts
@@ -81,16 +81,37 @@ describe('news-priority', () => {
       assert.equal(getNewsPriority(article), NewsPriority.P1);
     });
 
-    it('returns P1 for EU Chips Act news', () => {
+    it('returns P0 for EU Chips Act grants', () => {
       const article = createNewsItem(
-        'EU Chips Act allocates €43 billion for European semiconductor industry',
+        'EU Chips Act grant allocates €1.2 billion to Ireland semiconductor projects',
+      );
+      assert.equal(getNewsPriority(article), NewsPriority.P0);
+    });
+
+    it('returns P0 for Intel large investment (€1B+)', () => {
+      const article = createNewsItem(
+        'Intel announces €4 billion expansion at Leixlip facility',
+      );
+      assert.equal(getNewsPriority(article), NewsPriority.P0);
+    });
+
+    it('returns P0 for fab expansion', () => {
+      const article = createNewsItem(
+        'Intel fab expansion in Ireland to create 3000 jobs',
+      );
+      assert.equal(getNewsPriority(article), NewsPriority.P0);
+    });
+
+    it('returns P1 for Intel Ireland news without large investment', () => {
+      const article = createNewsItem(
+        'Intel Ireland showcases new 3nm chip technology',
       );
       assert.equal(getNewsPriority(article), NewsPriority.P1);
     });
 
-    it('returns P1 for Intel Leixlip news', () => {
+    it('returns P1 for EU Chips Act news without grant keyword', () => {
       const article = createNewsItem(
-        'Intel announces €4 billion expansion at Leixlip facility',
+        'EU Chips Act impact on Ireland semiconductor industry',
       );
       assert.equal(getNewsPriority(article), NewsPriority.P1);
     });


### PR DESCRIPTION
## Summary

Enhance news priority detection for semiconductor industry news.

### P0 Detection (BREAKING)

- **Fab expansion keywords**: fab expansion, chip plant, wafer fab
- **EU Chips Act grants**: chips act grant, chips act allocation
- **Large investments**: €500M+ or €1B+ with Intel/semiconductor/chip/fab context

### P1 Detection (HOT) - unchanged

- Intel Ireland, Analog Devices, EU Chips Act mentions
- Semiconductor breakthrough, chip manufacturing

### Score Boost

| Factor | Boost |
|--------|-------|
| Intel Ireland/Leixlip | +200 |
| EU Chips Act | +180 |
| Analog Devices | +150 |
| €1B investment | +100 per billion |

### Testing

- All 1813 unit tests pass
- Updated tests for new P0 thresholds

Closes #70