### PR TITLE
feat(FR #77): add Tyndall National Institute to semiconductor coverage

### DIFF
--- a/src/config/variants/ireland.ts
+++ b/src/config/variants/ireland.ts
@@ -109,6 +109,10 @@ export const FEEDS: Record<string, Feed[]> = {
       name: 'Analog Devices Ireland', 
       url: rss('https://news.google.com/rss/search?q=%22Analog+Devices%22+(Ireland+OR+Limerick)+when:14d&hl=en-IE&gl=IE&ceid=IE:en') 
     },
+    { 
+      name: 'Tyndall National Institute', 
+      url: rss('https://news.google.com/rss/search?q=%22Tyndall+National+Institute%22+OR+%22Tyndall+Cork%22+when:14d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
   ],
 
   // 爱尔兰商业新闻（使用 Google News 搜索）

--- a/src/data/semiconductor-hubs.ts
+++ b/src/data/semiconductor-hubs.ts
@@ -68,4 +68,16 @@ export const IRELAND_SEMICONDUCTOR_HUBS: SemiconductorHub[] = [
     description:
       'Manufacturing of high-speed connectors for semiconductor and data center applications.',
   },
+  {
+    id: 'tyndall-cork',
+    name: 'Tyndall National Institute',
+    company: 'Irish Government Research Institute',
+    lat: 51.8969,
+    lng: -8.5094,
+    employees: 600,
+    business: 'Semiconductor & Photonics R&D',
+    website: 'https://www.tyndall.ie',
+    description:
+      "Europe's leading research center for micro/nano-electronics and photonics. Partners with Intel, Analog Devices, and EU Chips Act initiatives.",
+  },
 ];

--- a/src/services/news-priority.ts
+++ b/src/services/news-priority.ts
@@ -95,6 +95,7 @@ const P1_KEYWORDS = [
   'chip manufacturing',
   'eu chips act',
   'leixlip',
+  'tyndall',
   'breakthrough',
   'research grant',
   'innovation hub',

--- a/tests/news-priority.test.mts
+++ b/tests/news-priority.test.mts
@@ -81,6 +81,13 @@ describe('news-priority', () => {
       assert.equal(getNewsPriority(article), NewsPriority.P1);
     });
 
+    it('returns P1 for Tyndall Institute news', () => {
+      const article = createNewsItem(
+        'Tyndall National Institute partners with Intel on quantum chip research',
+      );
+      assert.equal(getNewsPriority(article), NewsPriority.P1);
+    });
+
     it('returns P0 for EU Chips Act grants', () => {
       const article = createNewsItem(
         'EU Chips Act grant allocates €1.2 billion to Ireland semiconductor projects',

--- a/tests/semiconductor-hubs.test.mts
+++ b/tests/semiconductor-hubs.test.mts
@@ -6,8 +6,8 @@ import assert from 'node:assert';
 import { IRELAND_SEMICONDUCTOR_HUBS, type SemiconductorHub } from '../src/data/semiconductor-hubs.ts';
 
 describe('IRELAND_SEMICONDUCTOR_HUBS', () => {
-  it('contains 4 semiconductor facilities', () => {
-    assert.equal(IRELAND_SEMICONDUCTOR_HUBS.length, 4);
+  it('contains 5 semiconductor facilities', () => {
+    assert.equal(IRELAND_SEMICONDUCTOR_HUBS.length, 5);
   });
 
   it('all entries have required fields', () => {
@@ -47,5 +47,13 @@ describe('IRELAND_SEMICONDUCTOR_HUBS', () => {
     const ids = IRELAND_SEMICONDUCTOR_HUBS.map(h => h.id);
     const uniqueIds = new Set(ids);
     assert.equal(ids.length, uniqueIds.size, 'All IDs should be unique');
+  });
+
+  it('Tyndall National Institute is included', () => {
+    const tyndall = IRELAND_SEMICONDUCTOR_HUBS.find(h => h.id === 'tyndall-cork');
+    assert.ok(tyndall, 'Tyndall National Institute should be included');
+    assert.equal(tyndall?.company, 'Irish Government Research Institute');
+    assert.ok(tyndall?.employees >= 600, 'Tyndall should have 600+ employees');
+    assert.ok(tyndall?.lat > 51 && tyndall?.lat < 52.5, 'Tyndall should be in Cork area');
   });
 });


### PR DESCRIPTION
## Summary

Add Tyndall National Institute (Ireland's core semiconductor R&D center) to complete semiconductor industry coverage.

### Map Layer

| Facility | Location | Coordinates | Employees |
|----------|----------|-------------|-----------|
| Tyndall National Institute | Cork | 51.8969, -8.5094 | 600+ |

### News Source

Added Google News RSS for Tyndall-related news in ieSemiconductors feeds.

### Priority Detection

Added 'tyndall' to P1_KEYWORDS for high-priority news detection.

### Changes

- **semiconductor-hubs.ts**: Add tyndall-cork data point (now 5 facilities)
- **ireland.ts**: Add Tyndall RSS to ieSemiconductors feeds
- **news-priority.ts**: Add 'tyndall' to P1_KEYWORDS
- **tests**: Update facility count and add Tyndall test cases

### Testing

- All 1823 unit tests pass
- Typecheck passes

Closes #77