### PR TITLE
fix(FR #85): update Ireland map legend with new layers

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4458,11 +4458,13 @@ export class DeckGLMap {
     const isLight = getCurrentTheme() === 'light';
     const legendItems = SITE_VARIANT === 'ireland'
       ? [
-        { shape: shapes.circle('rgb(0, 140, 255)'), label: 'Big Tech Offices (HQs)' },
-        { shape: shapes.circle('rgb(0, 209, 255)'), label: 'Startup & University AI Hubs' },
-        { shape: shapes.circle('rgb(255, 179, 0)'), label: 'Accelerators / Incubators' },
-        { shape: shapes.circle('rgb(153, 102, 255)'), label: 'Cloud Regions / Infrastructure' },
-        { shape: shapes.square('rgb(136, 68, 255)'), label: 'AI Data Centers' },
+        { shape: shapes.circle('rgb(138, 43, 226)'), label: '💾 Semiconductor Hubs' },
+        { shape: shapes.circle('rgb(66, 133, 244)'), label: '🏢 Data Centers (Ireland)' },
+        { shape: shapes.circle('rgb(0, 122, 255)'), label: '🏢 Tech HQs (EMEA)' },
+        { shape: shapes.circle('rgb(22, 155, 98)'), label: '🦄 Irish Unicorns' },
+        { shape: shapes.circle('rgb(0, 209, 255)'), label: '🚀 Startup Hubs' },
+        { shape: shapes.circle('rgb(153, 102, 255)'), label: '☁️ Cloud Regions' },
+        { shape: shapes.circle('rgb(255, 179, 0)'), label: '🔶 Accelerators' },
       ]
       : SITE_VARIANT === 'tech'
         ? [


### PR DESCRIPTION
## Summary

Update the map legend for Ireland variant to display all the newly added layers (FR #17-23).

### Before

The legend showed generic items that didn't match the actual Ireland-specific layers.

### After

Legend now shows:
| Icon | Label | Color |
|------|-------|-------|
| 💾 | Semiconductor Hubs | Purple (rgb 138, 43, 226) |
| 🏢 | Data Centers (Ireland) | Google Blue (rgb 66, 133, 244) |
| 🏢 | Tech HQs (EMEA) | Blue (rgb 0, 122, 255) |
| 🦄 | Irish Unicorns | Irish Green (rgb 22, 155, 98) |
| 🚀 | Startup Hubs | Cyan (rgb 0, 209, 255) |
| ☁️ | Cloud Regions | Purple (rgb 153, 102, 255) |
| 🔶 | Accelerators | Orange (rgb 255, 179, 0) |

### Changes

- **DeckGLMap.ts**: Update legendItems array for Ireland variant

### Testing

- All 1860 unit tests pass
- Typecheck passes

Closes #85