### PR TITLE
feat(FR #89): add shape differentiation to Ireland map legend

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4475,15 +4475,17 @@ export class DeckGLMap {
       triangle: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,10 1,10" fill="${color}"/></svg>`,
       square: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="10" height="10" rx="1" fill="${color}"/></svg>`,
       hexagon: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 10.5,3.5 10.5,8.5 6,11 1.5,8.5 1.5,3.5" fill="${color}"/></svg>`,
+      diamond: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,6 6,11 1,6" fill="${color}" stroke="white" stroke-width="1"/></svg>`,
+      star: (color: string) => `<svg width="14" height="14" viewBox="0 0 14 14"><polygon points="7,1 8.5,5 13,5 9.5,8 11,13 7,10 3,13 4.5,8 1,5 5.5,5" fill="${color}" stroke="white" stroke-width="0.5"/></svg>`,
     };
 
     const isLight = getCurrentTheme() === 'light';
     const legendItems = SITE_VARIANT === 'ireland'
       ? [
-        { shape: shapes.circle('rgb(138, 43, 226)'), label: '💾 Semiconductor Hubs' },
-        { shape: shapes.circle('rgb(66, 133, 244)'), label: '🏢 Data Centers (Ireland)' },
-        { shape: shapes.circle('rgb(0, 122, 255)'), label: '🏢 Tech HQs (EMEA)' },
-        { shape: shapes.circle('rgb(22, 155, 98)'), label: '🦄 Irish Unicorns' },
+        { shape: shapes.diamond('rgb(138, 43, 226)'), label: '💎 Semiconductor Hubs' },
+        { shape: shapes.square('rgb(66, 133, 244)'), label: '▪️ Data Centers (Ireland)' },
+        { shape: shapes.hexagon('rgb(0, 122, 255)'), label: '⬢ Tech HQs (EMEA)' },
+        { shape: shapes.star('rgb(245, 158, 11)'), label: '⭐ Irish Unicorns' },
         { shape: shapes.circle('rgb(0, 209, 255)'), label: '🚀 Startup Hubs' },
         { shape: shapes.circle('rgb(153, 102, 255)'), label: '☁️ Cloud Regions' },
         { shape: shapes.circle('rgb(255, 179, 0)'), label: '🔶 Accelerators' },


### PR DESCRIPTION
## Summary

Add shape differentiation to the Ireland variant map legend to help users visually distinguish different facility types.

### Legend Shape Mapping

| Layer | Shape | Icon |
|-------|-------|------|
| Semiconductor Hubs | Diamond 💎 | Purple |
| Data Centers (Ireland) | Square ▪️ | Blue |
| Tech HQs (EMEA) | Hexagon ⬢ | Blue |
| Irish Unicorns | Star ⭐ | Gold |
| Startup Hubs | Circle 🚀 | Cyan |
| Cloud Regions | Circle ☁️ | Purple |
| Accelerators | Circle 🔶 | Orange |

### Technical Note

Map markers still use circles (deck.gl ScatterplotLayer limitation). Shape differentiation is implemented in the legend only. Full marker shape customization would require migrating to IconLayer with pre-rendered sprite sheets (future enhancement).

### Changes

- **DeckGLMap.ts**: Add diamond and star SVG shape generators
- **DeckGLMap.ts**: Update Ireland legend items with shape-specific icons

### Testing

- All 1881 unit tests pass
- Typecheck passes

Closes #89