### PR TITLE
feat(FR #93): implement IconLayer for map marker shape differentiation

### DIFF
--- a/public/icons/map-markers/diamond-large.svg
+++ b/public/icons/map-markers/diamond-large.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2 L22 12 L12 22 L2 12 Z" fill="white" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/icons/map-markers/diamond-medium.svg
+++ b/public/icons/map-markers/diamond-medium.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 1 L15 8 L8 15 L1 8 Z" fill="white" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/public/icons/map-markers/diamond-small.svg
+++ b/public/icons/map-markers/diamond-small.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 1 L11 6 L6 11 L1 6 Z" fill="white" stroke="white" stroke-width="1"/>
+</svg>

--- a/public/icons/map-markers/hexagon-large.svg
+++ b/public/icons/map-markers/hexagon-large.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="12,2 21,7 21,17 12,22 3,17 3,7" fill="white" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/icons/map-markers/hexagon-medium.svg
+++ b/public/icons/map-markers/hexagon-medium.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="8,1 14,4.5 14,11.5 8,15 2,11.5 2,4.5" fill="white" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/public/icons/map-markers/hexagon-small.svg
+++ b/public/icons/map-markers/hexagon-small.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="6,1 10.5,3.5 10.5,8.5 6,11 1.5,8.5 1.5,3.5" fill="white" stroke="white" stroke-width="1"/>
+</svg>

--- a/public/icons/map-markers/square-large.svg
+++ b/public/icons/map-markers/square-large.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="20" height="20" rx="2" fill="white" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/icons/map-markers/square-medium.svg
+++ b/public/icons/map-markers/square-medium.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="14" height="14" rx="1.5" fill="white" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/public/icons/map-markers/square-small.svg
+++ b/public/icons/map-markers/square-small.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="1" width="10" height="10" rx="1" fill="white" stroke="white" stroke-width="1"/>
+</svg>

--- a/public/icons/map-markers/star-large.svg
+++ b/public/icons/map-markers/star-large.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="14,2 17,10.5 26,10.5 19,16 22,25 14,19.5 6,25 9,16 2,10.5 11,10.5" fill="white" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/public/icons/map-markers/star-medium.svg
+++ b/public/icons/map-markers/star-medium.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="8,1 9.6,5.5 14.5,5.5 10.6,8.6 12,13.5 8,10.5 4,13.5 5.4,8.6 1.5,5.5 6.4,5.5" fill="white" stroke="white" stroke-width="1"/>
+</svg>

--- a/public/icons/map-markers/star-small.svg
+++ b/public/icons/map-markers/star-small.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="6,1 7.2,4.2 10.5,4.2 7.8,6.5 8.8,10 6,7.8 3.2,10 4.2,6.5 1.5,4.2 4.8,4.2" fill="white" stroke="white" stroke-width="0.5"/>
+</svg>

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -17,9 +17,12 @@ import {
   getDataCenterTier,
   getTechHQTier,
   getUnicornTier,
-  getTierRadius,
   getTierColor,
 } from '@/services/marker-tier';
+import {
+  getMarkerIconUrl,
+  getMarkerSizeForTier,
+} from '@/services/marker-icons';
 import Supercluster from 'supercluster';
 import type {
   MapLayers,
@@ -2723,54 +2726,71 @@ export class DeckGLMap {
    * Create semiconductor hubs layer for Ireland variant
    * Shows major semiconductor facilities (Intel, Analog Devices, etc.)
    */
-  private createSemiconductorHubsLayer(): ScatterplotLayer {
+  /**
+   * Create semiconductor hubs layer using IconLayer for diamond shape
+   */
+  private createSemiconductorHubsLayer(): IconLayer {
     // Pulse animation for Tier 1 facilities
     const pulse = 1.0 + 0.15 * Math.sin((this.pulseTime || Date.now()) / 1000);
 
-    return new ScatterplotLayer({
+    return new IconLayer({
       id: 'semiconductor-hubs-layer',
       data: IRELAND_SEMICONDUCTOR_HUBS,
       getPosition: (d) => [d.lng, d.lat],
-      getRadius: (d) => {
+      getIcon: (d) => {
         const tier = getSemiconductorTier(d.employees);
-        const baseRadius = getTierRadius(tier)[0];
-        // Only Tier 1 facilities pulse
-        return tier === 1 ? baseRadius * pulse : baseRadius;
+        return {
+          url: getMarkerIconUrl('diamond', tier),
+          width: getMarkerSizeForTier(tier, 'diamond'),
+          height: getMarkerSizeForTier(tier, 'diamond'),
+          mask: true, // Enables color tinting
+        };
       },
-      getFillColor: (d) => {
+      getSize: (d) => {
+        const tier = getSemiconductorTier(d.employees);
+        const baseSize = getMarkerSizeForTier(tier, 'diamond');
+        // Only Tier 1 facilities pulse
+        return tier === 1 ? baseSize * pulse : baseSize;
+      },
+      getColor: (d) => {
         const tier = getSemiconductorTier(d.employees);
         return getTierColor([138, 43, 226], tier); // Purple base
       },
-      radiusMinPixels: 6,
-      radiusMaxPixels: 28,
-      radiusScale: 1,
-      stroked: true,
-      getLineColor: [255, 255, 255, 220] as [number, number, number, number],
-      lineWidthMinPixels: 2,
+      sizeScale: 1,
+      sizeMinPixels: 8,
+      sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getRadius: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
     });
   }
 
   /**
-   * Create Ireland data centers layer
+   * Create Ireland data centers layer using IconLayer for square shape
    * Shows major cloud and colocation facilities (Google, Meta, Microsoft, AWS, Equinix)
    */
-  private createIrelandDataCentersLayer(): ScatterplotLayer<IrelandDataCenter> {
+  private createIrelandDataCentersLayer(): IconLayer<IrelandDataCenter> {
     // Pulse animation for Tier 1 facilities
     const pulse = 1.0 + 0.15 * Math.sin((this.pulseTime || Date.now()) / 1000);
 
-    return new ScatterplotLayer<IrelandDataCenter>({
+    return new IconLayer<IrelandDataCenter>({
       id: 'ireland-data-centers-layer',
       data: IRELAND_DATA_CENTERS,
       getPosition: (d) => [d.lng, d.lat],
-      getRadius: (d) => {
+      getIcon: (d) => {
         const tier = getDataCenterTier(d.operator);
-        const baseRadius = getTierRadius(tier)[0];
-        // Only Tier 1 facilities pulse
-        return tier === 1 ? baseRadius * pulse : baseRadius;
+        return {
+          url: getMarkerIconUrl('square', tier),
+          width: getMarkerSizeForTier(tier, 'square'),
+          height: getMarkerSizeForTier(tier, 'square'),
+          mask: true,
+        };
       },
-      getFillColor: (d) => {
+      getSize: (d) => {
+        const tier = getDataCenterTier(d.operator);
+        const baseSize = getMarkerSizeForTier(tier, 'square');
+        return tier === 1 ? baseSize * pulse : baseSize;
+      },
+      getColor: (d) => {
         const tier = getDataCenterTier(d.operator);
         // Color by operator with tier adjustment
         if (d.operator.includes('Google')) return getTierColor([66, 133, 244], tier);
@@ -2780,81 +2800,92 @@ export class DeckGLMap {
         if (d.operator.includes('Equinix')) return getTierColor([237, 28, 36], tier);
         return getTierColor([128, 128, 128], tier);
       },
-      radiusMinPixels: 6,
-      radiusMaxPixels: 28,
-      stroked: true,
-      getLineColor: [255, 255, 255, 220] as [number, number, number, number],
-      lineWidthMinPixels: 1.5,
+      sizeScale: 1,
+      sizeMinPixels: 8,
+      sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getRadius: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
     });
   }
 
   /**
-   * Create Ireland tech HQs layer
+   * Create Ireland tech HQs layer using IconLayer for hexagon shape
    * Shows EMEA headquarters of major tech companies (Google, Meta, Apple, etc.)
    */
-  private createIrelandTechHQsLayer(): ScatterplotLayer<IrelandTechHQ> {
+  private createIrelandTechHQsLayer(): IconLayer<IrelandTechHQ> {
     // Pulse animation for Tier 1 facilities
     const pulse = 1.0 + 0.15 * Math.sin((this.pulseTime || Date.now()) / 1000);
 
-    return new ScatterplotLayer<IrelandTechHQ>({
+    return new IconLayer<IrelandTechHQ>({
       id: 'ireland-tech-hqs-layer',
       data: IRELAND_TECH_HQS,
       getPosition: (d) => [d.lng, d.lat],
-      getRadius: (d) => {
+      getIcon: (d) => {
         const tier = getTechHQTier(d.employees);
-        const baseRadius = getTierRadius(tier)[0];
-        // Only Tier 1 facilities pulse
-        return tier === 1 ? baseRadius * pulse : baseRadius;
+        return {
+          url: getMarkerIconUrl('hexagon', tier),
+          width: getMarkerSizeForTier(tier, 'hexagon'),
+          height: getMarkerSizeForTier(tier, 'hexagon'),
+          mask: true,
+        };
       },
-      getFillColor: (d) => {
+      getSize: (d) => {
+        const tier = getTechHQTier(d.employees);
+        const baseSize = getMarkerSizeForTier(tier, 'hexagon');
+        return tier === 1 ? baseSize * pulse : baseSize;
+      },
+      getColor: (d) => {
         const tier = getTechHQTier(d.employees);
         return getTierColor([0, 122, 255], tier); // Blue base
       },
-      radiusMinPixels: 6,
-      radiusMaxPixels: 28,
-      stroked: true,
-      getLineColor: [255, 255, 255, 220] as [number, number, number, number],
-      lineWidthMinPixels: 1.5,
+      sizeScale: 1,
+      sizeMinPixels: 8,
+      sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getRadius: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
     });
   }
 
   /**
-   * Create Irish unicorns layer
+   * Create Irish unicorns layer using IconLayer for star shape
    * Shows local Irish tech companies with unicorn status or high growth
-   * Uses Irish green color scheme with glow effect for Tier 1
+   * Uses gold color for Tier 1 (star effect), Irish green for others
    */
-  private createIrishUnicornsLayer(): ScatterplotLayer<IrishUnicorn> {
+  private createIrishUnicornsLayer(): IconLayer<IrishUnicorn> {
     // Stronger pulse for unicorns (star-like glow effect)
     const pulse = 1.0 + 0.2 * Math.sin((this.pulseTime || Date.now()) / 800);
 
-    return new ScatterplotLayer<IrishUnicorn>({
+    return new IconLayer<IrishUnicorn>({
       id: 'irish-unicorns-layer',
       data: IRISH_UNICORNS,
       getPosition: (d) => [d.lng, d.lat],
-      getRadius: (d) => {
+      getIcon: (d) => {
         const tier = getUnicornTier(d.category);
-        const baseRadius = getTierRadius(tier)[0];
-        // Tier 1 unicorns get stronger pulse (star glow effect)
-        return tier === 1 ? baseRadius * pulse : baseRadius;
+        return {
+          url: getMarkerIconUrl('star', tier),
+          width: getMarkerSizeForTier(tier, 'star'),
+          height: getMarkerSizeForTier(tier, 'star'),
+          mask: true,
+        };
       },
-      getFillColor: (d) => {
+      getSize: (d) => {
         const tier = getUnicornTier(d.category);
-        // Gold color for unicorns instead of green for more "star" feel
+        const baseSize = getMarkerSizeForTier(tier, 'star');
+        // Tier 1 unicorns get stronger pulse (star glow effect)
+        return tier === 1 ? baseSize * pulse : baseSize;
+      },
+      getColor: (d) => {
+        const tier = getUnicornTier(d.category);
+        // Gold color for Tier 1, Irish green for others
         return tier === 1
           ? getTierColor([245, 158, 11], tier) // Gold for Tier 1
           : getTierColor([22, 155, 98], tier); // Irish green for others
       },
-      radiusMinPixels: 6,
-      radiusMaxPixels: 32,
-      stroked: true,
-      getLineColor: [255, 255, 255, 220] as [number, number, number, number],
-      lineWidthMinPixels: 2,
+      sizeScale: 1,
+      sizeMinPixels: 8,
+      sizeMaxPixels: 36,
       pickable: true,
-      updateTriggers: { getRadius: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
     });
   }
 

--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -1,0 +1,67 @@
+/**
+ * Marker Icons Service
+ *
+ * Provides icon mapping for deck.gl IconLayer.
+ * Uses white SVG icons that are colored via getColor accessor.
+ */
+
+import type { MarkerTier } from './marker-tier';
+
+export type MarkerShape = 'diamond' | 'square' | 'hexagon' | 'star';
+
+export interface IconMapping {
+  [key: string]: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    mask: boolean;
+  };
+}
+
+/**
+ * Get icon name based on shape and tier
+ */
+export function getMarkerIconName(shape: MarkerShape, tier: MarkerTier): string {
+  const sizeLabel = tier === 1 ? 'large' : tier === 2 ? 'medium' : 'small';
+  return `${shape}-${sizeLabel}`;
+}
+
+/**
+ * Get icon size based on tier
+ */
+export function getMarkerSizeForTier(tier: MarkerTier, shape: MarkerShape = 'diamond'): number {
+  if (shape === 'star' && tier === 1) return 28; // Stars are slightly larger
+  return tier === 1 ? 24 : tier === 2 ? 16 : 12;
+}
+
+/**
+ * Icon mapping for IconLayer using individual SVG files
+ * Each icon is a separate SVG that will be loaded from the icons folder
+ */
+export const MARKER_ICON_MAPPING: IconMapping = {
+  // Diamond shapes
+  'diamond-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'diamond-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'diamond-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  // Square shapes
+  'square-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'square-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'square-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  // Hexagon shapes
+  'hexagon-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'hexagon-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'hexagon-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  // Star shapes
+  'star-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'star-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'star-large': { x: 0, y: 0, width: 28, height: 28, mask: true },
+};
+
+/**
+ * Get icon URL for a specific shape and tier
+ */
+export function getMarkerIconUrl(shape: MarkerShape, tier: MarkerTier): string {
+  const iconName = getMarkerIconName(shape, tier);
+  return `/icons/map-markers/${iconName}.svg`;
+}

--- a/tests/marker-icons.test.mts
+++ b/tests/marker-icons.test.mts
@@ -1,0 +1,99 @@
+/**
+ * Marker Icons Service Tests
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  getMarkerIconName,
+  getMarkerSizeForTier,
+  getMarkerIconUrl,
+  MARKER_ICON_MAPPING,
+  type MarkerShape,
+} from '../src/services/marker-icons.ts';
+import type { MarkerTier } from '../src/services/marker-tier.ts';
+
+describe('Marker Icons Service', () => {
+  describe('getMarkerIconName', () => {
+    it('returns correct name for diamond shape', () => {
+      assert.equal(getMarkerIconName('diamond', 1), 'diamond-large');
+      assert.equal(getMarkerIconName('diamond', 2), 'diamond-medium');
+      assert.equal(getMarkerIconName('diamond', 3), 'diamond-small');
+    });
+
+    it('returns correct name for square shape', () => {
+      assert.equal(getMarkerIconName('square', 1), 'square-large');
+      assert.equal(getMarkerIconName('square', 2), 'square-medium');
+      assert.equal(getMarkerIconName('square', 3), 'square-small');
+    });
+
+    it('returns correct name for hexagon shape', () => {
+      assert.equal(getMarkerIconName('hexagon', 1), 'hexagon-large');
+      assert.equal(getMarkerIconName('hexagon', 2), 'hexagon-medium');
+      assert.equal(getMarkerIconName('hexagon', 3), 'hexagon-small');
+    });
+
+    it('returns correct name for star shape', () => {
+      assert.equal(getMarkerIconName('star', 1), 'star-large');
+      assert.equal(getMarkerIconName('star', 2), 'star-medium');
+      assert.equal(getMarkerIconName('star', 3), 'star-small');
+    });
+  });
+
+  describe('getMarkerSizeForTier', () => {
+    it('returns correct sizes for standard shapes', () => {
+      assert.equal(getMarkerSizeForTier(1, 'diamond'), 24);
+      assert.equal(getMarkerSizeForTier(2, 'diamond'), 16);
+      assert.equal(getMarkerSizeForTier(3, 'diamond'), 12);
+    });
+
+    it('returns larger size for Tier 1 star', () => {
+      assert.equal(getMarkerSizeForTier(1, 'star'), 28);
+      assert.equal(getMarkerSizeForTier(2, 'star'), 16);
+      assert.equal(getMarkerSizeForTier(3, 'star'), 12);
+    });
+
+    it('uses diamond size when shape not specified', () => {
+      assert.equal(getMarkerSizeForTier(1), 24);
+      assert.equal(getMarkerSizeForTier(2), 16);
+      assert.equal(getMarkerSizeForTier(3), 12);
+    });
+  });
+
+  describe('getMarkerIconUrl', () => {
+    it('returns correct URL path', () => {
+      assert.equal(getMarkerIconUrl('diamond', 1), '/icons/map-markers/diamond-large.svg');
+      assert.equal(getMarkerIconUrl('square', 2), '/icons/map-markers/square-medium.svg');
+      assert.equal(getMarkerIconUrl('hexagon', 3), '/icons/map-markers/hexagon-small.svg');
+      assert.equal(getMarkerIconUrl('star', 1), '/icons/map-markers/star-large.svg');
+    });
+  });
+
+  describe('MARKER_ICON_MAPPING', () => {
+    it('has all 12 icon mappings', () => {
+      assert.equal(Object.keys(MARKER_ICON_MAPPING).length, 12);
+    });
+
+    it('has correct dimensions for all icons', () => {
+      const shapes: MarkerShape[] = ['diamond', 'square', 'hexagon', 'star'];
+      const sizes = ['small', 'medium', 'large'];
+
+      for (const shape of shapes) {
+        for (const size of sizes) {
+          const key = `${shape}-${size}`;
+          const mapping = MARKER_ICON_MAPPING[key];
+          assert.ok(mapping, `Missing mapping for ${key}`);
+          assert.ok(mapping.width > 0, `${key} should have positive width`);
+          assert.ok(mapping.height > 0, `${key} should have positive height`);
+          assert.equal(mapping.mask, true, `${key} should have mask=true for color tinting`);
+        }
+      }
+    });
+
+    it('star-large is bigger than other large icons', () => {
+      assert.equal(MARKER_ICON_MAPPING['star-large'].width, 28);
+      assert.equal(MARKER_ICON_MAPPING['diamond-large'].width, 24);
+      assert.equal(MARKER_ICON_MAPPING['square-large'].width, 24);
+      assert.equal(MARKER_ICON_MAPPING['hexagon-large'].width, 24);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migrate Ireland map layers from ScatterplotLayer to IconLayer to display actual geometric shapes (not just circle markers).

### Shape Mapping

| Layer | Shape | Icon |
|-------|-------|------|
| Semiconductor Hubs | Diamond 💎 | Purple |
| Data Centers | Square ▪️ | Blue (varies by operator) |
| Tech HQs (EMEA) | Hexagon ⬢ | Blue |
| Irish Unicorns | Star ⭐ | Gold (Tier 1) / Green (others) |

### Implementation

- **SVG Icons**: 12 files (4 shapes × 3 sizes for Tier 1/2/3)
- **marker-icons.ts**: Service for icon URL/size helpers
- **IconLayer**: All 4 Ireland-specific layers use IconLayer with:
  - `mask: true` for color tinting via `getColor` accessor
  - `getIcon` returns icon config based on tier
  - `getSize` includes pulse animation for Tier 1
  - `updateTriggers` preserves animation

### Changes

- **public/icons/map-markers/**: New SVG icon files
- **marker-icons.ts**: Icon mapping service
- **DeckGLMap.ts**: Update 4 layer methods to use IconLayer

### Testing

- All 1894 unit tests pass
- Typecheck passes

Closes #93