### PR TITLE
fix(FR #93): use cached icon objects for stable IconLayer references

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -20,7 +20,7 @@ import {
   getTierColor,
 } from '@/services/marker-tier';
 import {
-  getMarkerIconUrl,
+  getMarkerIcon,
   getMarkerSizeForTier,
 } from '@/services/marker-icons';
 import Supercluster from 'supercluster';
@@ -2737,15 +2737,8 @@ export class DeckGLMap {
       id: 'semiconductor-hubs-layer',
       data: IRELAND_SEMICONDUCTOR_HUBS,
       getPosition: (d) => [d.lng, d.lat],
-      getIcon: (d) => {
-        const tier = getSemiconductorTier(d.employees);
-        return {
-          url: getMarkerIconUrl('diamond', tier),
-          width: getMarkerSizeForTier(tier, 'diamond'),
-          height: getMarkerSizeForTier(tier, 'diamond'),
-          mask: true, // Enables color tinting
-        };
-      },
+      // Use cached icon objects for stable references
+      getIcon: (d) => getMarkerIcon('diamond', getSemiconductorTier(d.employees)),
       getSize: (d) => {
         const tier = getSemiconductorTier(d.employees);
         const baseSize = getMarkerSizeForTier(tier, 'diamond');
@@ -2760,7 +2753,7 @@ export class DeckGLMap {
       sizeMinPixels: 8,
       sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime },
     });
   }
 
@@ -2776,15 +2769,8 @@ export class DeckGLMap {
       id: 'ireland-data-centers-layer',
       data: IRELAND_DATA_CENTERS,
       getPosition: (d) => [d.lng, d.lat],
-      getIcon: (d) => {
-        const tier = getDataCenterTier(d.operator);
-        return {
-          url: getMarkerIconUrl('square', tier),
-          width: getMarkerSizeForTier(tier, 'square'),
-          height: getMarkerSizeForTier(tier, 'square'),
-          mask: true,
-        };
-      },
+      // Use cached icon objects for stable references
+      getIcon: (d) => getMarkerIcon('square', getDataCenterTier(d.operator)),
       getSize: (d) => {
         const tier = getDataCenterTier(d.operator);
         const baseSize = getMarkerSizeForTier(tier, 'square');
@@ -2804,7 +2790,7 @@ export class DeckGLMap {
       sizeMinPixels: 8,
       sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime },
     });
   }
 
@@ -2820,15 +2806,8 @@ export class DeckGLMap {
       id: 'ireland-tech-hqs-layer',
       data: IRELAND_TECH_HQS,
       getPosition: (d) => [d.lng, d.lat],
-      getIcon: (d) => {
-        const tier = getTechHQTier(d.employees);
-        return {
-          url: getMarkerIconUrl('hexagon', tier),
-          width: getMarkerSizeForTier(tier, 'hexagon'),
-          height: getMarkerSizeForTier(tier, 'hexagon'),
-          mask: true,
-        };
-      },
+      // Use cached icon objects for stable references
+      getIcon: (d) => getMarkerIcon('hexagon', getTechHQTier(d.employees)),
       getSize: (d) => {
         const tier = getTechHQTier(d.employees);
         const baseSize = getMarkerSizeForTier(tier, 'hexagon');
@@ -2842,7 +2821,7 @@ export class DeckGLMap {
       sizeMinPixels: 8,
       sizeMaxPixels: 32,
       pickable: true,
-      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime },
     });
   }
 
@@ -2859,15 +2838,8 @@ export class DeckGLMap {
       id: 'irish-unicorns-layer',
       data: IRISH_UNICORNS,
       getPosition: (d) => [d.lng, d.lat],
-      getIcon: (d) => {
-        const tier = getUnicornTier(d.category);
-        return {
-          url: getMarkerIconUrl('star', tier),
-          width: getMarkerSizeForTier(tier, 'star'),
-          height: getMarkerSizeForTier(tier, 'star'),
-          mask: true,
-        };
-      },
+      // Use cached icon objects for stable references
+      getIcon: (d) => getMarkerIcon('star', getUnicornTier(d.category)),
       getSize: (d) => {
         const tier = getUnicornTier(d.category);
         const baseSize = getMarkerSizeForTier(tier, 'star');
@@ -2885,7 +2857,7 @@ export class DeckGLMap {
       sizeMinPixels: 8,
       sizeMaxPixels: 36,
       pickable: true,
-      updateTriggers: { getSize: this.pulseTime, getIcon: this.pulseTime },
+      updateTriggers: { getSize: this.pulseTime },
     });
   }
 

--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -1,22 +1,22 @@
 /**
  * Marker Icons Service
  *
- * Provides icon mapping for deck.gl IconLayer.
- * Uses white SVG icons that are colored via getColor accessor.
+ * Provides icon definitions for deck.gl IconLayer.
+ * Uses pre-cached icon objects for stable references.
  */
 
 import type { MarkerTier } from './marker-tier';
 
 export type MarkerShape = 'diamond' | 'square' | 'hexagon' | 'star';
 
-export interface IconMapping {
-  [key: string]: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    mask: boolean;
-  };
+/**
+ * Icon definition for deck.gl IconLayer
+ */
+export interface IconDefinition {
+  url: string;
+  width: number;
+  height: number;
+  mask: boolean;
 }
 
 /**
@@ -36,10 +36,33 @@ export function getMarkerSizeForTier(tier: MarkerTier, shape: MarkerShape = 'dia
 }
 
 /**
- * Icon mapping for IconLayer using individual SVG files
- * Each icon is a separate SVG that will be loaded from the icons folder
+ * Pre-cached icon definitions for stable references
+ * deck.gl IconLayer requires stable object references for getIcon
  */
-export const MARKER_ICON_MAPPING: IconMapping = {
+const ICON_CACHE: Record<string, IconDefinition> = {};
+
+/**
+ * Get cached icon definition for a specific shape and tier
+ * Returns the same object reference for the same parameters
+ */
+export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinition {
+  const key = `${shape}-${tier}`;
+  if (!ICON_CACHE[key]) {
+    const size = getMarkerSizeForTier(tier, shape);
+    ICON_CACHE[key] = {
+      url: `/icons/map-markers/${getMarkerIconName(shape, tier)}.svg`,
+      width: size,
+      height: size,
+      mask: true,
+    };
+  }
+  return ICON_CACHE[key];
+}
+
+/**
+ * Icon mapping for IconLayer (legacy format, kept for tests)
+ */
+export const MARKER_ICON_MAPPING: Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> = {
   // Diamond shapes
   'diamond-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'diamond-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },

--- a/tests/marker-icons.test.mts
+++ b/tests/marker-icons.test.mts
@@ -7,6 +7,7 @@ import {
   getMarkerIconName,
   getMarkerSizeForTier,
   getMarkerIconUrl,
+  getMarkerIcon,
   MARKER_ICON_MAPPING,
   type MarkerShape,
 } from '../src/services/marker-icons.ts';
@@ -94,6 +95,35 @@ describe('Marker Icons Service', () => {
       assert.equal(MARKER_ICON_MAPPING['diamond-large'].width, 24);
       assert.equal(MARKER_ICON_MAPPING['square-large'].width, 24);
       assert.equal(MARKER_ICON_MAPPING['hexagon-large'].width, 24);
+    });
+  });
+
+  describe('getMarkerIcon', () => {
+    it('returns cached icon definition with correct properties', () => {
+      const icon = getMarkerIcon('diamond', 1);
+      assert.equal(icon.url, '/icons/map-markers/diamond-large.svg');
+      assert.equal(icon.width, 24);
+      assert.equal(icon.height, 24);
+      assert.equal(icon.mask, true);
+    });
+
+    it('returns same object reference for same parameters (caching)', () => {
+      const icon1 = getMarkerIcon('square', 2);
+      const icon2 = getMarkerIcon('square', 2);
+      assert.strictEqual(icon1, icon2, 'Should return same cached object');
+    });
+
+    it('returns different objects for different parameters', () => {
+      const icon1 = getMarkerIcon('hexagon', 1);
+      const icon2 = getMarkerIcon('hexagon', 2);
+      assert.notStrictEqual(icon1, icon2);
+    });
+
+    it('star tier 1 has larger dimensions', () => {
+      const starIcon = getMarkerIcon('star', 1);
+      const diamondIcon = getMarkerIcon('diamond', 1);
+      assert.equal(starIcon.width, 28);
+      assert.equal(diamondIcon.width, 24);
     });
   });
 });


### PR DESCRIPTION
## Problem

地图标记仍显示为圆形，IconLayer 没有正确渲染 SVG 图标形状。

## Root Cause

deck.gl IconLayer 的 `getIcon` accessor 要求返回稳定的对象引用。之前的实现每次调用都返回新对象，导致图标无法正确渲染。

## Fix

1. **添加 `getMarkerIcon()` 函数**：内部缓存机制，相同参数返回相同对象引用
2. **替换所有 getIcon 实现**：使用缓存的 `getMarkerIcon()` 调用
3. **移除 getIcon 的 updateTriggers**：图标本身不会随动画变化

## Changes

- **marker-icons.ts**: 添加 `ICON_CACHE` 和 `getMarkerIcon()` 函数
- **DeckGLMap.ts**: 4 个图层方法使用 `getMarkerIcon()` 
- **marker-icons.test.mts**: 添加缓存功能的单元测试

## Testing

✅ All 1898 unit tests pass

Fixes rendering issue from #93