### PR TITLE
fix(FR #93): use inline SVG data URLs for IconLayer

### DIFF
--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -2,7 +2,7 @@
  * Marker Icons Service
  *
  * Provides icon definitions for deck.gl IconLayer.
- * Uses pre-cached icon objects for stable references.
+ * Uses inline SVG data URLs for reliable rendering.
  */
 
 import type { MarkerTier } from './marker-tier';
@@ -31,8 +31,34 @@ export function getMarkerIconName(shape: MarkerShape, tier: MarkerTier): string 
  * Get icon size based on tier
  */
 export function getMarkerSizeForTier(tier: MarkerTier, shape: MarkerShape = 'diamond'): number {
-  if (shape === 'star' && tier === 1) return 28; // Stars are slightly larger
+  if (shape === 'star' && tier === 1) return 28;
   return tier === 1 ? 24 : tier === 2 ? 16 : 12;
+}
+
+/**
+ * SVG path definitions for each shape
+ * All shapes are white filled for mask coloring
+ */
+const SVG_PATHS: Record<MarkerShape, string> = {
+  diamond: 'M12 2 L22 12 L12 22 L2 12 Z',
+  square: 'M3 3 H21 V21 H3 Z',
+  hexagon: 'M12 2 L21 7 L21 17 L12 22 L3 17 L3 7 Z',
+  star: 'M12 2 L14.5 9 L22 9 L16 14 L18.5 22 L12 17 L5.5 22 L8 14 L2 9 L9.5 9 Z',
+};
+
+/**
+ * Generate SVG data URL for a shape
+ */
+function generateSvgDataUrl(shape: MarkerShape, size: number): string {
+  const path = SVG_PATHS[shape];
+  // Scale path to fit size (original paths are designed for 24x24)
+  const scale = size / 24;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24">
+    <g transform="scale(${scale})">
+      <path d="${path}" fill="white"/>
+    </g>
+  </svg>`;
+  return `data:image/svg+xml;base64,${btoa(svg)}`;
 }
 
 /**
@@ -50,7 +76,7 @@ export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinit
   if (!ICON_CACHE[key]) {
     const size = getMarkerSizeForTier(tier, shape);
     ICON_CACHE[key] = {
-      url: `/icons/map-markers/${getMarkerIconName(shape, tier)}.svg`,
+      url: generateSvgDataUrl(shape, size),
       width: size,
       height: size,
       mask: true,
@@ -63,19 +89,15 @@ export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinit
  * Icon mapping for IconLayer (legacy format, kept for tests)
  */
 export const MARKER_ICON_MAPPING: Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> = {
-  // Diamond shapes
   'diamond-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'diamond-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'diamond-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  // Square shapes
   'square-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'square-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'square-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  // Hexagon shapes
   'hexagon-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'hexagon-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'hexagon-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  // Star shapes
   'star-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'star-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'star-large': { x: 0, y: 0, width: 28, height: 28, mask: true },

--- a/tests/marker-icons.test.mts
+++ b/tests/marker-icons.test.mts
@@ -101,7 +101,7 @@ describe('Marker Icons Service', () => {
   describe('getMarkerIcon', () => {
     it('returns cached icon definition with correct properties', () => {
       const icon = getMarkerIcon('diamond', 1);
-      assert.equal(icon.url, '/icons/map-markers/diamond-large.svg');
+      assert.ok(icon.url.startsWith('data:image/svg+xml;base64,'), 'URL should be a data URL');
       assert.equal(icon.width, 24);
       assert.equal(icon.height, 24);
       assert.equal(icon.mask, true);
@@ -124,6 +124,15 @@ describe('Marker Icons Service', () => {
       const diamondIcon = getMarkerIcon('diamond', 1);
       assert.equal(starIcon.width, 28);
       assert.equal(diamondIcon.width, 24);
+    });
+
+    it('generates valid SVG data URL', () => {
+      const icon = getMarkerIcon('diamond', 1);
+      const base64Part = icon.url.replace('data:image/svg+xml;base64,', '');
+      const decoded = atob(base64Part);
+      assert.ok(decoded.includes('<svg'), 'Should contain SVG element');
+      assert.ok(decoded.includes('<path'), 'Should contain path element');
+      assert.ok(decoded.includes('fill="white"'), 'Should have white fill for masking');
     });
   });
 });


### PR DESCRIPTION
## Problem

IconLayer 使用外部 SVG 文件 URL 可能无法正确加载图标。

## Fix

改用 inline base64 编码的 SVG data URL，确保图标可靠渲染：

- 添加 `SVG_PATHS` 定义各形状的路径
- 添加 `generateSvgDataUrl()` 生成内联 data URL
- 更新 `getMarkerIcon()` 使用 data URL 而非文件路径

## Testing

✅ All 1899 unit tests pass