### PR TITLE
feat(FR #107): redesign map marker shapes

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -2746,7 +2746,7 @@ export class DeckGLMap {
       data: IRELAND_SEMICONDUCTOR_HUBS,
       getPosition: (d) => [d.lng, d.lat],
       // Use cached icon objects for stable references
-      getIcon: (d) => getMarkerIcon('diamond', getSemiconductorTier(d.employees)),
+      getIcon: (d) => getMarkerIcon('circle', getSemiconductorTier(d.employees)),
       getSize: (d) => {
         const tier = getSemiconductorTier(d.employees);
         const baseSize = getMarkerSizeForTier(tier, 'diamond');
@@ -2778,7 +2778,7 @@ export class DeckGLMap {
       data: IRELAND_DATA_CENTERS,
       getPosition: (d) => [d.lng, d.lat],
       // Use cached icon objects for stable references
-      getIcon: (d) => getMarkerIcon('square', getDataCenterTier(d.operator)),
+      getIcon: (d) => getMarkerIcon('circle', getDataCenterTier(d.operator)),
       getSize: (d) => {
         const tier = getDataCenterTier(d.operator);
         const baseSize = getMarkerSizeForTier(tier, 'square');
@@ -2815,10 +2815,10 @@ export class DeckGLMap {
       data: IRELAND_TECH_HQS,
       getPosition: (d) => [d.lng, d.lat],
       // Use cached icon objects for stable references
-      getIcon: (d) => getMarkerIcon('hexagon', getTechHQTier(d.employees)),
+      getIcon: (d) => getMarkerIcon('diamond', getTechHQTier(d.employees)),
       getSize: (d) => {
         const tier = getTechHQTier(d.employees);
-        const baseSize = getMarkerSizeForTier(tier, 'hexagon');
+        const baseSize = getMarkerSizeForTier(tier, 'diamond');
         return tier === 1 ? baseSize * pulse : baseSize;
       },
       getColor: (d) => {
@@ -2847,11 +2847,11 @@ export class DeckGLMap {
       data: IRISH_UNICORNS,
       getPosition: (d) => [d.lng, d.lat],
       // Use cached icon objects for stable references
-      getIcon: (d) => getMarkerIcon('star', getUnicornTier(d.category)),
+      getIcon: (d) => getMarkerIcon('triangle', getUnicornTier(d.category)),
       getSize: (d) => {
         const tier = getUnicornTier(d.category);
-        const baseSize = getMarkerSizeForTier(tier, 'star');
-        // Tier 1 unicorns get stronger pulse (star glow effect)
+        const baseSize = getMarkerSizeForTier(tier, 'triangle');
+        // Tier 1 unicorns get stronger pulse
         return tier === 1 ? baseSize * pulse : baseSize;
       },
       getColor: (d) => {
@@ -4523,13 +4523,13 @@ export class DeckGLMap {
     const isLight = getCurrentTheme() === 'light';
     const legendItems = isIrelandVariant()
       ? [
-        { shape: shapes.diamond('rgb(138, 43, 226)'), label: '💎 Semiconductor Hubs' },
-        { shape: shapes.square('rgb(66, 133, 244)'), label: '▪️ Data Centers (Ireland)' },
-        { shape: shapes.hexagon('rgb(0, 122, 255)'), label: '⬢ Tech HQs (EMEA)' },
-        { shape: shapes.star('rgb(245, 158, 11)'), label: '⭐ Irish Unicorns' },
-        { shape: shapes.circle('rgb(0, 209, 255)'), label: '🚀 Startup Hubs' },
-        { shape: shapes.circle('rgb(153, 102, 255)'), label: '☁️ Cloud Regions' },
-        { shape: shapes.circle('rgb(255, 179, 0)'), label: '🔶 Accelerators' },
+        { shape: shapes.circle('rgb(138, 43, 226)'), label: '⚫ Semiconductor Hubs' },
+        { shape: shapes.circle('rgb(66, 133, 244)'), label: '⚫ Data Centers (Ireland)' },
+        { shape: shapes.diamond('rgb(0, 122, 255)'), label: '💎 Tech HQs (EMEA)' },
+        { shape: shapes.triangle('rgb(245, 158, 11)'), label: '▲ Irish Unicorns' },
+        { shape: shapes.circle('rgb(0, 209, 255)'), label: '⚫ Startup Hubs' },
+        { shape: shapes.square('rgb(153, 102, 255)'), label: '▪️ Cloud Regions' },
+        { shape: shapes.diamond('rgb(255, 179, 0)'), label: '💎 Accelerators' },
       ]
       : SITE_VARIANT === 'tech'
         ? [

--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -7,7 +7,7 @@
 
 import type { MarkerTier } from './marker-tier';
 
-export type MarkerShape = 'diamond' | 'square' | 'hexagon' | 'star';
+export type MarkerShape = 'circle' | 'diamond' | 'triangle' | 'square';
 
 /**
  * Icon definition for deck.gl IconLayer
@@ -32,20 +32,25 @@ export function getMarkerIconName(shape: MarkerShape, tier: MarkerTier): string 
 /**
  * Get icon size based on tier
  */
-export function getMarkerSizeForTier(tier: MarkerTier, shape: MarkerShape = 'diamond'): number {
-  if (shape === 'star' && tier === 1) return 28;
+export function getMarkerSizeForTier(tier: MarkerTier, _shape: MarkerShape = 'circle'): number {
   return tier === 1 ? 24 : tier === 2 ? 16 : 12;
 }
 
 /**
  * SVG path definitions for each shape
  * All shapes are white filled for mask coloring
+ *
+ * Shapes (4 total - simplified design):
+ * - circle: Core infrastructure (Semiconductor Hubs, Data Centers)
+ * - diamond: Professional/HQ (Tech HQs, Accelerators)
+ * - triangle: Growth/Unicorns (Irish Unicorns)
+ * - square: Foundation (Cloud Regions)
  */
 const SVG_PATHS: Record<MarkerShape, string> = {
+  circle: 'M12 2 A10 10 0 1 0 12 22 A10 10 0 1 0 12 2',
   diamond: 'M12 2 L22 12 L12 22 L2 12 Z',
+  triangle: 'M12 3 L22 21 L2 21 Z',
   square: 'M3 3 H21 V21 H3 Z',
-  hexagon: 'M12 2 L21 7 L21 17 L12 22 L3 17 L3 7 Z',
-  star: 'M12 2 L14.5 9 L22 9 L16 14 L18.5 22 L12 17 L5.5 22 L8 14 L2 9 L9.5 9 Z',
 };
 
 /**
@@ -93,18 +98,18 @@ export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinit
  * Icon mapping for IconLayer (legacy format, kept for tests)
  */
 export const MARKER_ICON_MAPPING: Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> = {
+  'circle-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'circle-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'circle-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
   'diamond-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'diamond-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'diamond-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  'triangle-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
+  'triangle-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
+  'triangle-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
   'square-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
   'square-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
   'square-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  'hexagon-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'hexagon-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'hexagon-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  'star-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'star-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'star-large': { x: 0, y: 0, width: 28, height: 28, mask: true },
 };
 
 /**

--- a/tests/marker-icons.test.mts
+++ b/tests/marker-icons.test.mts
@@ -1,5 +1,11 @@
 /**
  * Marker Icons Service Tests
+ *
+ * Tests for simplified marker shapes (FR #107):
+ * - circle: Core infrastructure (Semiconductor Hubs, Data Centers)
+ * - diamond: Professional/HQ (Tech HQs, Accelerators)
+ * - triangle: Growth/Unicorns (Irish Unicorns)
+ * - square: Foundation (Cloud Regions)
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
@@ -15,10 +21,22 @@ import type { MarkerTier } from '../src/services/marker-tier.ts';
 
 describe('Marker Icons Service', () => {
   describe('getMarkerIconName', () => {
+    it('returns correct name for circle shape', () => {
+      assert.equal(getMarkerIconName('circle', 1), 'circle-large');
+      assert.equal(getMarkerIconName('circle', 2), 'circle-medium');
+      assert.equal(getMarkerIconName('circle', 3), 'circle-small');
+    });
+
     it('returns correct name for diamond shape', () => {
       assert.equal(getMarkerIconName('diamond', 1), 'diamond-large');
       assert.equal(getMarkerIconName('diamond', 2), 'diamond-medium');
       assert.equal(getMarkerIconName('diamond', 3), 'diamond-small');
+    });
+
+    it('returns correct name for triangle shape', () => {
+      assert.equal(getMarkerIconName('triangle', 1), 'triangle-large');
+      assert.equal(getMarkerIconName('triangle', 2), 'triangle-medium');
+      assert.equal(getMarkerIconName('triangle', 3), 'triangle-small');
     });
 
     it('returns correct name for square shape', () => {
@@ -26,34 +44,25 @@ describe('Marker Icons Service', () => {
       assert.equal(getMarkerIconName('square', 2), 'square-medium');
       assert.equal(getMarkerIconName('square', 3), 'square-small');
     });
-
-    it('returns correct name for hexagon shape', () => {
-      assert.equal(getMarkerIconName('hexagon', 1), 'hexagon-large');
-      assert.equal(getMarkerIconName('hexagon', 2), 'hexagon-medium');
-      assert.equal(getMarkerIconName('hexagon', 3), 'hexagon-small');
-    });
-
-    it('returns correct name for star shape', () => {
-      assert.equal(getMarkerIconName('star', 1), 'star-large');
-      assert.equal(getMarkerIconName('star', 2), 'star-medium');
-      assert.equal(getMarkerIconName('star', 3), 'star-small');
-    });
   });
 
   describe('getMarkerSizeForTier', () => {
-    it('returns correct sizes for standard shapes', () => {
-      assert.equal(getMarkerSizeForTier(1, 'diamond'), 24);
-      assert.equal(getMarkerSizeForTier(2, 'diamond'), 16);
-      assert.equal(getMarkerSizeForTier(3, 'diamond'), 12);
+    it('returns correct sizes for all tiers', () => {
+      assert.equal(getMarkerSizeForTier(1, 'circle'), 24);
+      assert.equal(getMarkerSizeForTier(2, 'circle'), 16);
+      assert.equal(getMarkerSizeForTier(3, 'circle'), 12);
     });
 
-    it('returns larger size for Tier 1 star', () => {
-      assert.equal(getMarkerSizeForTier(1, 'star'), 28);
-      assert.equal(getMarkerSizeForTier(2, 'star'), 16);
-      assert.equal(getMarkerSizeForTier(3, 'star'), 12);
+    it('returns same sizes for all shapes (simplified design)', () => {
+      const shapes: MarkerShape[] = ['circle', 'diamond', 'triangle', 'square'];
+      for (const shape of shapes) {
+        assert.equal(getMarkerSizeForTier(1, shape), 24, `Tier 1 ${shape} should be 24px`);
+        assert.equal(getMarkerSizeForTier(2, shape), 16, `Tier 2 ${shape} should be 16px`);
+        assert.equal(getMarkerSizeForTier(3, shape), 12, `Tier 3 ${shape} should be 12px`);
+      }
     });
 
-    it('uses diamond size when shape not specified', () => {
+    it('uses circle size when shape not specified', () => {
       assert.equal(getMarkerSizeForTier(1), 24);
       assert.equal(getMarkerSizeForTier(2), 16);
       assert.equal(getMarkerSizeForTier(3), 12);
@@ -62,20 +71,20 @@ describe('Marker Icons Service', () => {
 
   describe('getMarkerIconUrl', () => {
     it('returns correct URL path', () => {
-      assert.equal(getMarkerIconUrl('diamond', 1), '/icons/map-markers/diamond-large.svg');
-      assert.equal(getMarkerIconUrl('square', 2), '/icons/map-markers/square-medium.svg');
-      assert.equal(getMarkerIconUrl('hexagon', 3), '/icons/map-markers/hexagon-small.svg');
-      assert.equal(getMarkerIconUrl('star', 1), '/icons/map-markers/star-large.svg');
+      assert.equal(getMarkerIconUrl('circle', 1), '/icons/map-markers/circle-large.svg');
+      assert.equal(getMarkerIconUrl('diamond', 2), '/icons/map-markers/diamond-medium.svg');
+      assert.equal(getMarkerIconUrl('triangle', 3), '/icons/map-markers/triangle-small.svg');
+      assert.equal(getMarkerIconUrl('square', 1), '/icons/map-markers/square-large.svg');
     });
   });
 
   describe('MARKER_ICON_MAPPING', () => {
-    it('has all 12 icon mappings', () => {
+    it('has all 12 icon mappings (4 shapes × 3 tiers)', () => {
       assert.equal(Object.keys(MARKER_ICON_MAPPING).length, 12);
     });
 
     it('has correct dimensions for all icons', () => {
-      const shapes: MarkerShape[] = ['diamond', 'square', 'hexagon', 'star'];
+      const shapes: MarkerShape[] = ['circle', 'diamond', 'triangle', 'square'];
       const sizes = ['small', 'medium', 'large'];
 
       for (const shape of shapes) {
@@ -90,17 +99,17 @@ describe('Marker Icons Service', () => {
       }
     });
 
-    it('star-large is bigger than other large icons', () => {
-      assert.equal(MARKER_ICON_MAPPING['star-large'].width, 28);
-      assert.equal(MARKER_ICON_MAPPING['diamond-large'].width, 24);
-      assert.equal(MARKER_ICON_MAPPING['square-large'].width, 24);
-      assert.equal(MARKER_ICON_MAPPING['hexagon-large'].width, 24);
+    it('all large icons have same size (simplified design)', () => {
+      assert.equal(MARKER_ICON_MAPPING['circle-large']?.width, 24);
+      assert.equal(MARKER_ICON_MAPPING['diamond-large']?.width, 24);
+      assert.equal(MARKER_ICON_MAPPING['triangle-large']?.width, 24);
+      assert.equal(MARKER_ICON_MAPPING['square-large']?.width, 24);
     });
   });
 
   describe('getMarkerIcon', () => {
     it('returns cached icon definition with correct properties', () => {
-      const icon = getMarkerIcon('diamond', 1);
+      const icon = getMarkerIcon('circle', 1);
       assert.ok(icon.url.startsWith('data:image/svg+xml;base64,'), 'URL should be a data URL');
       assert.equal(icon.width, 24);
       assert.equal(icon.height, 24);
@@ -108,31 +117,70 @@ describe('Marker Icons Service', () => {
     });
 
     it('returns same object reference for same parameters (caching)', () => {
-      const icon1 = getMarkerIcon('square', 2);
-      const icon2 = getMarkerIcon('square', 2);
+      const icon1 = getMarkerIcon('diamond', 2);
+      const icon2 = getMarkerIcon('diamond', 2);
       assert.strictEqual(icon1, icon2, 'Should return same cached object');
     });
 
     it('returns different objects for different parameters', () => {
-      const icon1 = getMarkerIcon('hexagon', 1);
-      const icon2 = getMarkerIcon('hexagon', 2);
+      const icon1 = getMarkerIcon('triangle', 1);
+      const icon2 = getMarkerIcon('triangle', 2);
       assert.notStrictEqual(icon1, icon2);
     });
 
-    it('star tier 1 has larger dimensions', () => {
-      const starIcon = getMarkerIcon('star', 1);
+    it('all tier 1 icons have same dimensions (simplified design)', () => {
+      const circleIcon = getMarkerIcon('circle', 1);
       const diamondIcon = getMarkerIcon('diamond', 1);
-      assert.equal(starIcon.width, 28);
+      const triangleIcon = getMarkerIcon('triangle', 1);
+      const squareIcon = getMarkerIcon('square', 1);
+      assert.equal(circleIcon.width, 24);
       assert.equal(diamondIcon.width, 24);
+      assert.equal(triangleIcon.width, 24);
+      assert.equal(squareIcon.width, 24);
     });
 
-    it('generates valid SVG data URL', () => {
-      const icon = getMarkerIcon('diamond', 1);
+    it('generates valid SVG data URL for circle', () => {
+      const icon = getMarkerIcon('circle', 1);
+      const base64Part = icon.url.replace('data:image/svg+xml;base64,', '');
+      const decoded = atob(base64Part);
+      assert.ok(decoded.includes('<svg'), 'Should contain SVG element');
+      assert.ok(decoded.includes('<path') || decoded.includes('A10 10'), 'Should contain circle path');
+      assert.ok(decoded.includes('fill="white"'), 'Should have white fill for masking');
+    });
+
+    it('generates valid SVG data URL for triangle', () => {
+      const icon = getMarkerIcon('triangle', 1);
       const base64Part = icon.url.replace('data:image/svg+xml;base64,', '');
       const decoded = atob(base64Part);
       assert.ok(decoded.includes('<svg'), 'Should contain SVG element');
       assert.ok(decoded.includes('<path'), 'Should contain path element');
       assert.ok(decoded.includes('fill="white"'), 'Should have white fill for masking');
+    });
+  });
+
+  describe('Shape usage guidelines (FR #107)', () => {
+    it('circle is valid for core infrastructure layers', () => {
+      // Semiconductor Hubs, Data Centers, Startup Hubs
+      const icon = getMarkerIcon('circle', 1);
+      assert.ok(icon, 'Circle should be available');
+    });
+
+    it('diamond is valid for professional/HQ layers', () => {
+      // Tech HQs, Accelerators
+      const icon = getMarkerIcon('diamond', 1);
+      assert.ok(icon, 'Diamond should be available');
+    });
+
+    it('triangle is valid for growth/unicorn layers', () => {
+      // Irish Unicorns
+      const icon = getMarkerIcon('triangle', 1);
+      assert.ok(icon, 'Triangle should be available');
+    });
+
+    it('square is valid for foundation layers', () => {
+      // Cloud Regions
+      const icon = getMarkerIcon('square', 1);
+      assert.ok(icon, 'Square should be available');
     });
   });
 });


### PR DESCRIPTION
## Summary

简化地图标记形状，提升视觉美观度。

### Shape Changes

| 图层 | 旧形状 | 新形状 | 颜色 |
|------|--------|--------|------|
| Semiconductor Hubs | 💎 菱形 | ⚫ 圆形 | 紫色 |
| Data Centers | ▪️ 正方形 | ⚫ 圆形 | 蓝色 |
| Tech HQs (EMEA) | ⬢ 六边形 | 💎 菱形 | 深蓝 |
| Irish Unicorns | ⭐ 五角星 | ▲ 三角形 | 橙色 |
| Startup Hubs | - | ⚫ 圆形 | 青色 |
| Cloud Regions | - | ▪️ 正方形 | 紫色 |
| Accelerators | - | 💎 菱形 | 金色 |

### Design Principles

```
最重要 → ⚫ 圆形 (Core Infrastructure)
重要   → 💎 菱形 (HQ/Accelerators)
次要   → ▲ 三角形 (Unicorns)
辅助   → ▪️ 正方形 (Cloud)
```

### Changes

- `src/services/marker-icons.ts`: 更新 MarkerShape 类型和 SVG 路径
- `src/components/DeckGLMap.ts`: 更新 Ireland 图层使用新形状
- `tests/marker-icons.test.mts`: 更新测试用例

### Testing

✅ 21 marker-icons tests pass
✅ Typecheck passes

Closes #107