### PR TITLE
fix(FR #112): improve cross-platform visibility for deck.gl controls

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14767,21 +14767,34 @@ a.prediction-link:hover {
 
 /* deck.gl Layer Toggles */
 .deckgl-layer-toggles {
-  position: absolute;
+  /* Use fixed positioning for reliable cross-platform visibility (Windows/Mac) */
+  position: fixed;
   bottom: 10px;
   left: 10px;
   z-index: 1000;
   background: var(--panel-bg);
   border: 1px solid var(--border-strong);
   border-radius: 6px;
+  /* Fixed width to avoid Windows font rendering differences */
+  width: 260px;
   max-width: 260px;
   max-height: 50vh;
-  display: flex !important; /* Ensure visibility on all screen sizes */
+  /* Explicit flex display with vendor prefixes for older browsers */
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex !important;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
   flex-direction: column;
   overflow: hidden;
+  -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   visibility: visible !important;
   opacity: 1 !important;
+  /* Ensure element is not clipped by parent containers */
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 
 .deckgl-layer-toggles .toggle-header {
@@ -15190,12 +15203,21 @@ a.prediction-link:hover {
 
 /* deck.gl Legend - horizontal bar at bottom center */
 .deckgl-legend {
-  position: absolute;
+  /* Use fixed positioning for reliable cross-platform visibility (Windows/Mac) */
+  position: fixed;
   bottom: 8px;
   left: 50%;
-  transform: translateX(-50%);
+  /* Use translateX with translateZ for GPU acceleration and reliable rendering */
+  -webkit-transform: translateX(-50%) translateZ(0);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%) translateZ(0);
   z-index: 1000;
-  display: flex !important; /* Ensure visibility on all screen sizes */
+  /* Explicit flex display with vendor prefixes for older browsers */
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex !important;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
   gap: 12px;
   background: var(--bg);
@@ -15204,6 +15226,9 @@ a.prediction-link:hover {
   padding: 5px 12px;
   visibility: visible !important;
   opacity: 1 !important;
+  /* Prevent clipping by parent containers */
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 
 .deckgl-legend .legend-label-title {
@@ -18986,8 +19011,9 @@ body.has-breaking-alert .panels-grid {
   }
 
   /* Ensure deck.gl controls are visible in ultra-wide layout */
-  .map-section .deckgl-layer-toggles,
-  .map-section .deckgl-legend {
+  /* Note: These use fixed positioning so parent selector is for specificity only */
+  .deckgl-layer-toggles,
+  .deckgl-legend {
     z-index: 1001;
   }
 


### PR DESCRIPTION
## Summary

改善 Windows 平台上 Layers 面板和 Legend 的可见性。

### Root Cause

1. **overflow 裁剪**：父容器的 `overflow: hidden` 可能裁剪绝对定位的子元素
2. **高 DPI 缩放**：Windows 125%/150% 缩放会降低 CSS 视口宽度（1920px @ 150% = 1280px CSS）
3. **浏览器差异**：Windows 浏览器对 flex 和 transform 的处理可能不同

### CSS Changes

| 组件 | 修改 |
|------|------|
| `.deckgl-layer-toggles` | position: absolute → fixed, 固定宽度 260px |
| `.deckgl-layer-toggles` | 添加 -webkit-box, -ms-flexbox 前缀 |
| `.deckgl-layer-toggles` | 添加 transform: translateZ(0) GPU 加速 |
| `.deckgl-legend` | position: absolute → fixed |
| `.deckgl-legend` | 添加 -webkit-transform, -ms-transform 前缀 |
| `.deckgl-legend` | 添加 backface-visibility: hidden 稳定渲染 |

### Testing

**Windows 平台测试：**
- [ ] Chrome: Layers 和 Legend 可见
- [ ] Edge: Layers 和 Legend 可见
- [ ] Firefox: Layers 和 Legend 可见

**Mac 回归测试：**
- [ ] Chrome: Layers 和 Legend 可见，布局正常

⚠️ **注意**：需要在 Windows 环境下验证修复效果

Closes #112