### PR TITLE
feat(FR #114): optimize map marker style with worldmonitor aesthetics

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -2755,7 +2755,8 @@ export class DeckGLMap {
       },
       getColor: (d) => {
         const tier = getSemiconductorTier(d.employees);
-        return getTierColor([138, 43, 226], tier); // Purple base
+        // Vibrant purple (#A855F7) - worldmonitor style high-saturation color
+        return getTierColor([168, 85, 247], tier);
       },
       sizeScale: 1,
       sizeMinPixels: 8,
@@ -2786,13 +2787,14 @@ export class DeckGLMap {
       },
       getColor: (d) => {
         const tier = getDataCenterTier(d.operator);
-        // Color by operator with tier adjustment
+        // Color by operator with tier adjustment - brand colors
         if (d.operator.includes('Google')) return getTierColor([66, 133, 244], tier);
         if (d.operator.includes('Meta')) return getTierColor([24, 119, 242], tier);
         if (d.operator.includes('Microsoft')) return getTierColor([0, 164, 239], tier);
         if (d.operator.includes('Amazon')) return getTierColor([255, 153, 0], tier);
         if (d.operator.includes('Equinix')) return getTierColor([237, 28, 36], tier);
-        return getTierColor([128, 128, 128], tier);
+        // Vibrant cyan (#0EA5E9) for other operators - worldmonitor style
+        return getTierColor([14, 165, 233], tier);
       },
       sizeScale: 1,
       sizeMinPixels: 8,
@@ -2823,7 +2825,8 @@ export class DeckGLMap {
       },
       getColor: (d) => {
         const tier = getTechHQTier(d.employees);
-        return getTierColor([0, 122, 255], tier); // Blue base
+        // Vibrant teal (#14B8A6) - worldmonitor style high-saturation color
+        return getTierColor([20, 184, 166], tier);
       },
       sizeScale: 1,
       sizeMinPixels: 8,
@@ -2856,10 +2859,9 @@ export class DeckGLMap {
       },
       getColor: (d) => {
         const tier = getUnicornTier(d.category);
-        // Gold color for Tier 1, Irish green for others
-        return tier === 1
-          ? getTierColor([245, 158, 11], tier) // Gold for Tier 1
-          : getTierColor([22, 155, 98], tier); // Irish green for others
+        // Vibrant orange (#F97316) - worldmonitor style high-saturation color
+        // Unified color for all tiers for cleaner visual
+        return getTierColor([249, 115, 22], tier);
       },
       sizeScale: 1,
       sizeMinPixels: 8,
@@ -4511,22 +4513,24 @@ export class DeckGLMap {
     legend.className = 'map-legend deckgl-legend';
 
     // SVG shapes for different marker types
+    // worldmonitor style: semi-transparent fill (0.85 opacity), no stroke/shadow
     const shapes = {
-      circle: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5" fill="${color}"/></svg>`,
-      triangle: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,10 1,10" fill="${color}"/></svg>`,
-      square: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="10" height="10" rx="1" fill="${color}"/></svg>`,
-      hexagon: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 10.5,3.5 10.5,8.5 6,11 1.5,8.5 1.5,3.5" fill="${color}"/></svg>`,
-      diamond: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,6 6,11 1,6" fill="${color}" stroke="white" stroke-width="1"/></svg>`,
-      star: (color: string) => `<svg width="14" height="14" viewBox="0 0 14 14"><polygon points="7,1 8.5,5 13,5 9.5,8 11,13 7,10 3,13 4.5,8 1,5 5.5,5" fill="${color}" stroke="white" stroke-width="0.5"/></svg>`,
+      circle: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5" fill="${color}" fill-opacity="0.85"/></svg>`,
+      triangle: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,10 1,10" fill="${color}" fill-opacity="0.85"/></svg>`,
+      square: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><rect x="1" y="1" width="10" height="10" rx="1" fill="${color}" fill-opacity="0.85"/></svg>`,
+      hexagon: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 10.5,3.5 10.5,8.5 6,11 1.5,8.5 1.5,3.5" fill="${color}" fill-opacity="0.85"/></svg>`,
+      diamond: (color: string) => `<svg width="12" height="12" viewBox="0 0 12 12"><polygon points="6,1 11,6 6,11 1,6" fill="${color}" fill-opacity="0.85"/></svg>`,
+      star: (color: string) => `<svg width="14" height="14" viewBox="0 0 14 14"><polygon points="7,1 8.5,5 13,5 9.5,8 11,13 7,10 3,13 4.5,8 1,5 5.5,5" fill="${color}" fill-opacity="0.85"/></svg>`,
     };
 
     const isLight = getCurrentTheme() === 'light';
+    // Ireland legend with worldmonitor-style vibrant colors
     const legendItems = isIrelandVariant()
       ? [
-        { shape: shapes.circle('rgb(138, 43, 226)'), label: '⚫ Semiconductor Hubs' },
-        { shape: shapes.circle('rgb(66, 133, 244)'), label: '⚫ Data Centers (Ireland)' },
-        { shape: shapes.diamond('rgb(0, 122, 255)'), label: '💎 Tech HQs (EMEA)' },
-        { shape: shapes.triangle('rgb(245, 158, 11)'), label: '▲ Irish Unicorns' },
+        { shape: shapes.circle('rgb(168, 85, 247)'), label: '⚫ Semiconductor Hubs' },    // #A855F7
+        { shape: shapes.circle('rgb(14, 165, 233)'), label: '⚫ Data Centers (Ireland)' }, // #0EA5E9
+        { shape: shapes.diamond('rgb(20, 184, 166)'), label: '💎 Tech HQs (EMEA)' },      // #14B8A6
+        { shape: shapes.triangle('rgb(249, 115, 22)'), label: '▲ Irish Unicorns' },       // #F97316
         { shape: shapes.circle('rgb(0, 209, 255)'), label: '⚫ Startup Hubs' },
         { shape: shapes.square('rgb(153, 102, 255)'), label: '▪️ Cloud Regions' },
         { shape: shapes.diamond('rgb(255, 179, 0)'), label: '💎 Accelerators' },

--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -55,14 +55,16 @@ const SVG_PATHS: Record<MarkerShape, string> = {
 
 /**
  * Generate SVG data URL for a shape
+ * Uses semi-transparent fill (0.85 opacity) for worldmonitor-style appearance
  */
 function generateSvgDataUrl(shape: MarkerShape, size: number): string {
   const path = SVG_PATHS[shape];
   // Scale path to fit size (original paths are designed for 24x24)
   const scale = size / 24;
+  // Semi-transparent fill for cleaner, more professional look (worldmonitor style)
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24">
     <g transform="scale(${scale})">
-      <path d="${path}" fill="white"/>
+      <path d="${path}" fill="white" fill-opacity="0.85"/>
     </g>
   </svg>`;
   return `data:image/svg+xml;base64,${btoa(svg)}`;


### PR DESCRIPTION
## Summary

参考 worldmonitor.app 风格，优化地图标记视觉效果。

### 颜色更新（更高饱和度）

| 图层 | 旧颜色 | 新颜色 |
|------|--------|--------|
| Semiconductor Hubs | rgb(138,43,226) | **rgb(168,85,247)** #A855F7 |
| Data Centers (default) | rgb(128,128,128) | **rgb(14,165,233)** #0EA5E9 |
| Tech HQs | rgb(0,122,255) | **rgb(20,184,166)** #14B8A6 |
| Irish Unicorns | rgb(245,158,11) | **rgb(249,115,22)** #F97316 |

### 样式更新

- ✨ 添加 `fill-opacity="0.85"` 半透明效果
- 🎯 去除 Legend 中形状的描边（更简洁）
- 🎨 Legend 颜色与地图标记同步

### worldmonitor 设计原则

- **半透明填充**：在地图上更自然
- **高饱和度颜色**：在深色背景上醒目
- **无描边/阴影**：极简美学

### 文件变更

- `src/services/marker-icons.ts`: SVG 添加 fill-opacity
- `src/components/DeckGLMap.ts`: 更新 getColor 和 Legend

Closes #114