### PR TITLE
feat(FR #120): add Company Profile system

### DIFF
--- a/api/companies.js
+++ b/api/companies.js
@@ -1,0 +1,283 @@
+/**
+ * Companies API
+ *
+ * Company profile data for Irish tech ecosystem.
+ * Uses static data with Redis caching for news.
+ *
+ * Routes:
+ * - GET /api/companies - List/search companies
+ * - GET /api/companies/:slug - Get company by slug
+ * - GET /api/companies/:slug/news - Get company news
+ */
+
+import { jsonResponse } from './_json-response.js';
+import { withCors } from './_cors.js';
+
+// Static company data (imported inline for Edge Function compatibility)
+const IRELAND_COMPANIES = [
+  {
+    id: 'stripe',
+    slug: 'stripe',
+    name: 'Stripe',
+    description: 'Financial infrastructure platform for the internet.',
+    founded: 2010,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Fintech',
+    employeeCount: '5001-10000',
+    website: 'https://stripe.com',
+    funding: { total: '€2.5B', lastRound: 'Series H', lastRoundDate: '2021-03' },
+    people: [
+      { name: 'Patrick Collison', title: 'CEO' },
+      { name: 'John Collison', title: 'President' },
+    ],
+    tags: ['unicorn', 'irish-founded', 'tech-hq'],
+    coordinates: [-6.2603, 53.3498],
+  },
+  {
+    id: 'intercom',
+    slug: 'intercom',
+    name: 'Intercom',
+    description: 'Customer messaging platform.',
+    founded: 2011,
+    headquarters: 'Dublin, Ireland',
+    industry: 'SaaS',
+    employeeCount: '501-1000',
+    website: 'https://intercom.com',
+    funding: { total: '€240M', lastRound: 'Series D' },
+    tags: ['unicorn', 'irish-founded'],
+    coordinates: [-6.2489, 53.3389],
+  },
+  {
+    id: 'intel-ireland',
+    slug: 'intel-ireland',
+    name: 'Intel Ireland',
+    description: 'Intel\'s largest manufacturing site outside the US.',
+    founded: 1989,
+    headquarters: 'Leixlip, Co. Kildare',
+    industry: 'Semiconductor',
+    employeeCount: '5001-10000',
+    website: 'https://intel.ie',
+    tags: ['semiconductor', 'multinational'],
+    coordinates: [-6.4967, 53.3631],
+  },
+  {
+    id: 'google-ireland',
+    slug: 'google-ireland',
+    name: 'Google Ireland',
+    description: 'Google\'s EMEA headquarters.',
+    founded: 2003,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '5001-10000',
+    website: 'https://google.ie',
+    tags: ['tech-hq', 'multinational'],
+    coordinates: [-6.2376, 53.3392],
+  },
+  {
+    id: 'meta-ireland',
+    slug: 'meta-ireland',
+    name: 'Meta Ireland',
+    description: 'Meta\'s EMEA headquarters.',
+    founded: 2008,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Consumer',
+    employeeCount: '5001-10000',
+    website: 'https://meta.com',
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2297, 53.3400],
+  },
+  {
+    id: 'apple-ireland',
+    slug: 'apple-ireland',
+    name: 'Apple Ireland',
+    description: 'Apple\'s European operations hub.',
+    founded: 1980,
+    headquarters: 'Cork, Ireland',
+    industry: 'Consumer',
+    employeeCount: '5001-10000',
+    website: 'https://apple.com/ie',
+    tags: ['tech-hq', 'multinational'],
+    coordinates: [-8.4958, 51.8985],
+  },
+  {
+    id: 'microsoft-ireland',
+    slug: 'microsoft-ireland',
+    name: 'Microsoft Ireland',
+    description: 'Microsoft\'s EMEA operations center.',
+    founded: 1985,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '1001-5000',
+    website: 'https://microsoft.com/ie',
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2220, 53.2860],
+  },
+  {
+    id: 'amazon-ireland',
+    slug: 'amazon-ireland',
+    name: 'Amazon Ireland',
+    description: 'Amazon\'s European operations including AWS.',
+    founded: 2004,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '5001-10000',
+    website: 'https://amazon.ie',
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2389, 53.3331],
+  },
+  {
+    id: 'analog-devices',
+    slug: 'analog-devices',
+    name: 'Analog Devices',
+    description: 'Global semiconductor company.',
+    founded: 1976,
+    headquarters: 'Limerick, Ireland',
+    industry: 'Semiconductor',
+    employeeCount: '1001-5000',
+    website: 'https://analog.com',
+    tags: ['semiconductor', 'multinational'],
+    coordinates: [-8.6305, 52.6638],
+  },
+  {
+    id: 'fenergo',
+    slug: 'fenergo',
+    name: 'Fenergo',
+    description: 'Client lifecycle management software.',
+    founded: 2009,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Fintech',
+    employeeCount: '501-1000',
+    website: 'https://fenergo.com',
+    funding: { total: '€80M', lastRound: 'Growth' },
+    tags: ['irish-founded', 'startup'],
+    coordinates: [-6.2654, 53.3448],
+  },
+];
+
+// Redis helpers
+async function redisCmd(cmd, ...args) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const cmdUrl = `${url}/${[cmd, ...args.map(encodeURIComponent)].join('/')}`;
+  const resp = await fetch(cmdUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!resp.ok) return null;
+
+  const data = await resp.json();
+  return data.result;
+}
+
+async function redisGet(key) {
+  const result = await redisCmd('get', key);
+  if (!result) return null;
+  try {
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+// Handler
+async function handler(request) {
+  const reqUrl = new URL(request.url);
+  const method = request.method;
+  const pathParts = reqUrl.pathname.split('/').filter(Boolean);
+
+  // Only GET requests
+  if (method !== 'GET') {
+    return jsonResponse({ success: false, error: 'Method not allowed' }, { status: 405 });
+  }
+
+  try {
+    // GET /api/companies/:slug/news
+    if (pathParts.length >= 3 && pathParts[2] === 'news') {
+      const slug = pathParts[1];
+      const company = IRELAND_COMPANIES.find((c) => c.slug === slug);
+
+      if (!company) {
+        return jsonResponse({ success: false, error: 'Company not found' }, { status: 404 });
+      }
+
+      // Try to get cached news
+      const cached = await redisGet(`companies:news:${slug}`);
+      const news = cached || [];
+      const limit = parseInt(reqUrl.searchParams.get('limit') || '20', 10);
+
+      return jsonResponse({
+        success: true,
+        news: news.slice(0, limit),
+        total: news.length,
+      });
+    }
+
+    // GET /api/companies/:slug
+    if (pathParts.length >= 2 && pathParts[1] !== '') {
+      const slug = pathParts[1];
+      const company = IRELAND_COMPANIES.find((c) => c.slug === slug);
+
+      if (!company) {
+        return jsonResponse({ success: false, error: 'Company not found' }, { status: 404 });
+      }
+
+      return jsonResponse({ success: true, company });
+    }
+
+    // GET /api/companies - List/search
+    const filters = {
+      q: reqUrl.searchParams.get('q') || undefined,
+      industry: reqUrl.searchParams.get('industry') || undefined,
+      tag: reqUrl.searchParams.get('tag') || undefined,
+      location: reqUrl.searchParams.get('location') || undefined,
+      offset: parseInt(reqUrl.searchParams.get('offset') || '0', 10),
+      limit: parseInt(reqUrl.searchParams.get('limit') || '20', 10),
+    };
+
+    let companies = [...IRELAND_COMPANIES];
+
+    // Apply filters
+    if (filters.q) {
+      const q = filters.q.toLowerCase();
+      companies = companies.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          (c.description && c.description.toLowerCase().includes(q)) ||
+          c.industry.toLowerCase().includes(q)
+      );
+    }
+
+    if (filters.industry) {
+      companies = companies.filter((c) => c.industry === filters.industry);
+    }
+
+    if (filters.tag) {
+      companies = companies.filter((c) => c.tags && c.tags.includes(filters.tag));
+    }
+
+    if (filters.location) {
+      const loc = filters.location.toLowerCase();
+      companies = companies.filter((c) =>
+        c.headquarters.toLowerCase().includes(loc)
+      );
+    }
+
+    const total = companies.length;
+
+    // Pagination
+    companies = companies.slice(filters.offset, filters.offset + filters.limit);
+
+    return jsonResponse({ success: true, companies, total, filters });
+  } catch (e) {
+    console.error('[companies API] Error:', e);
+    return jsonResponse({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export default withCors(handler);
+
+export const config = {
+  runtime: 'edge',
+};

--- a/src/data/ireland-companies.ts
+++ b/src/data/ireland-companies.ts
@@ -1,0 +1,305 @@
+/**
+ * Ireland Tech Companies Static Data
+ *
+ * Manually curated list of major tech companies in Ireland.
+ * This serves as the initial data source before external API integration.
+ */
+
+import type { Company } from '@/types/company';
+
+/**
+ * Static company data for Ireland tech ecosystem
+ */
+export const IRELAND_COMPANIES: Company[] = [
+  // Unicorns & Major Tech HQs
+  {
+    id: 'stripe',
+    slug: 'stripe',
+    name: 'Stripe',
+    description: 'Financial infrastructure platform for the internet. Founded in Ireland, now a global fintech leader.',
+    founded: 2010,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Fintech',
+    employeeCount: '5001-10000',
+    website: 'https://stripe.com',
+    linkedin: 'https://linkedin.com/company/stripe',
+    twitter: 'stripe',
+    funding: {
+      total: '€2.5B',
+      lastRound: 'Series H',
+      lastRoundDate: '2021-03',
+      investors: ['Sequoia', 'Andreessen Horowitz', 'Tiger Global'],
+    },
+    people: [
+      { name: 'Patrick Collison', title: 'CEO', linkedin: 'https://linkedin.com/in/patrickcollison' },
+      { name: 'John Collison', title: 'President', linkedin: 'https://linkedin.com/in/johncollison' },
+    ],
+    tags: ['unicorn', 'irish-founded', 'tech-hq'],
+    coordinates: [-6.2603, 53.3498],
+    address: 'Grand Canal Dock, Dublin 2',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'intercom',
+    slug: 'intercom',
+    name: 'Intercom',
+    description: 'Customer messaging platform that helps businesses connect with customers.',
+    founded: 2011,
+    headquarters: 'Dublin, Ireland',
+    industry: 'SaaS',
+    employeeCount: '501-1000',
+    website: 'https://intercom.com',
+    linkedin: 'https://linkedin.com/company/intercom',
+    funding: {
+      total: '€240M',
+      lastRound: 'Series D',
+      lastRoundDate: '2018-09',
+    },
+    people: [
+      { name: 'Eoghan McCabe', title: 'CEO' },
+    ],
+    tags: ['unicorn', 'irish-founded'],
+    coordinates: [-6.2489, 53.3389],
+    updatedAt: '2026-03-24',
+  },
+
+  // Semiconductor
+  {
+    id: 'intel-ireland',
+    slug: 'intel-ireland',
+    name: 'Intel Ireland',
+    description: 'Intel\'s largest manufacturing site outside the US, producing advanced chips.',
+    founded: 1989,
+    headquarters: 'Leixlip, Co. Kildare',
+    industry: 'Semiconductor',
+    employeeCount: '5001-10000',
+    website: 'https://intel.ie',
+    linkedin: 'https://linkedin.com/company/intel-corporation',
+    people: [
+      { name: 'Eamonn Sinnott', title: 'VP & GM Intel Ireland' },
+    ],
+    relatedCompanies: [
+      { slug: 'intel', name: 'Intel Corporation', relation: 'parent' },
+    ],
+    tags: ['semiconductor', 'multinational'],
+    coordinates: [-6.4967, 53.3631],
+    address: 'Collinstown Industrial Park, Leixlip',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'analog-devices',
+    slug: 'analog-devices',
+    name: 'Analog Devices',
+    description: 'Global semiconductor company with major R&D and manufacturing in Ireland.',
+    founded: 1976,
+    headquarters: 'Limerick, Ireland',
+    industry: 'Semiconductor',
+    employeeCount: '1001-5000',
+    website: 'https://analog.com',
+    linkedin: 'https://linkedin.com/company/analog-devices',
+    tags: ['semiconductor', 'multinational'],
+    coordinates: [-8.6305, 52.6638],
+    updatedAt: '2026-03-24',
+  },
+
+  // Big Tech EMEA HQs
+  {
+    id: 'google-ireland',
+    slug: 'google-ireland',
+    name: 'Google Ireland',
+    description: 'Google\'s EMEA headquarters, handling operations across Europe, Middle East, and Africa.',
+    founded: 2003,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '5001-10000',
+    website: 'https://google.ie',
+    linkedin: 'https://linkedin.com/company/google',
+    relatedCompanies: [
+      { slug: 'alphabet', name: 'Alphabet Inc.', relation: 'parent' },
+    ],
+    tags: ['tech-hq', 'multinational'],
+    coordinates: [-6.2376, 53.3392],
+    address: 'Barrow Street, Dublin 4',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'meta-ireland',
+    slug: 'meta-ireland',
+    name: 'Meta Ireland',
+    description: 'Meta\'s EMEA headquarters, managing Facebook, Instagram, and WhatsApp operations.',
+    founded: 2008,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Consumer',
+    employeeCount: '5001-10000',
+    website: 'https://meta.com',
+    linkedin: 'https://linkedin.com/company/meta',
+    relatedCompanies: [
+      { slug: 'meta', name: 'Meta Platforms Inc.', relation: 'parent' },
+    ],
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2297, 53.3400],
+    address: 'Merrion Road, Dublin 4',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'apple-ireland',
+    slug: 'apple-ireland',
+    name: 'Apple Ireland',
+    description: 'Apple\'s European operations hub, including AppleCare and iTunes.',
+    founded: 1980,
+    headquarters: 'Cork, Ireland',
+    industry: 'Consumer',
+    employeeCount: '5001-10000',
+    website: 'https://apple.com/ie',
+    linkedin: 'https://linkedin.com/company/apple',
+    relatedCompanies: [
+      { slug: 'apple', name: 'Apple Inc.', relation: 'parent' },
+    ],
+    tags: ['tech-hq', 'multinational'],
+    coordinates: [-8.4958, 51.8985],
+    address: 'Hollyhill Industrial Estate, Cork',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'microsoft-ireland',
+    slug: 'microsoft-ireland',
+    name: 'Microsoft Ireland',
+    description: 'Microsoft\'s EMEA operations center and engineering hub.',
+    founded: 1985,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '1001-5000',
+    website: 'https://microsoft.com/ie',
+    linkedin: 'https://linkedin.com/company/microsoft',
+    relatedCompanies: [
+      { slug: 'microsoft', name: 'Microsoft Corporation', relation: 'parent' },
+    ],
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2220, 53.2860],
+    address: 'Leopardstown, Dublin 18',
+    updatedAt: '2026-03-24',
+  },
+  {
+    id: 'amazon-ireland',
+    slug: 'amazon-ireland',
+    name: 'Amazon Ireland',
+    description: 'Amazon\'s European operations including AWS and retail.',
+    founded: 2004,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Cloud',
+    employeeCount: '5001-10000',
+    website: 'https://amazon.ie',
+    linkedin: 'https://linkedin.com/company/amazon',
+    relatedCompanies: [
+      { slug: 'amazon', name: 'Amazon.com Inc.', relation: 'parent' },
+    ],
+    tags: ['tech-hq', 'multinational', 'data-center'],
+    coordinates: [-6.2389, 53.3331],
+    address: 'Burlington Plaza, Dublin 4',
+    updatedAt: '2026-03-24',
+  },
+
+  // Data Centers
+  {
+    id: 'equinix-dublin',
+    slug: 'equinix-dublin',
+    name: 'Equinix Dublin',
+    description: 'Major colocation data center provider serving Ireland\'s tech industry.',
+    founded: 2007,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Data Center',
+    employeeCount: '201-500',
+    website: 'https://equinix.ie',
+    linkedin: 'https://linkedin.com/company/equinix',
+    tags: ['data-center', 'multinational'],
+    coordinates: [-6.2749, 53.3494],
+    updatedAt: '2026-03-24',
+  },
+
+  // Fintech
+  {
+    id: 'fenergo',
+    slug: 'fenergo',
+    name: 'Fenergo',
+    description: 'Client lifecycle management software for financial institutions.',
+    founded: 2009,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Fintech',
+    employeeCount: '501-1000',
+    website: 'https://fenergo.com',
+    linkedin: 'https://linkedin.com/company/fenergo',
+    funding: {
+      total: '€80M',
+      lastRound: 'Growth',
+      lastRoundDate: '2020-06',
+    },
+    tags: ['irish-founded', 'startup'],
+    coordinates: [-6.2654, 53.3448],
+    updatedAt: '2026-03-24',
+  },
+
+  // Healthcare/Pharma Tech
+  {
+    id: 'icon-plc',
+    slug: 'icon-plc',
+    name: 'ICON plc',
+    description: 'Global provider of outsourced drug development and commercialisation services.',
+    founded: 1990,
+    headquarters: 'Dublin, Ireland',
+    industry: 'Healthcare',
+    employeeCount: '10000+',
+    website: 'https://iconplc.com',
+    linkedin: 'https://linkedin.com/company/icon-plc',
+    tags: ['irish-founded', 'multinational'],
+    coordinates: [-6.2297, 53.3145],
+    updatedAt: '2026-03-24',
+  },
+];
+
+/**
+ * Get company by slug
+ */
+export function getCompanyBySlug(slug: string): Company | undefined {
+  return IRELAND_COMPANIES.find((c) => c.slug === slug);
+}
+
+/**
+ * Get company by ID
+ */
+export function getCompanyById(id: string): Company | undefined {
+  return IRELAND_COMPANIES.find((c) => c.id === id);
+}
+
+/**
+ * Search companies by query
+ */
+export function searchCompanies(query: string): Company[] {
+  const q = query.toLowerCase();
+  return IRELAND_COMPANIES.filter(
+    (c) =>
+      c.name.toLowerCase().includes(q) ||
+      c.description?.toLowerCase().includes(q) ||
+      c.industry.toLowerCase().includes(q)
+  );
+}
+
+/**
+ * Get companies by tag
+ */
+export function getCompaniesByTag(tag: string): Company[] {
+  return IRELAND_COMPANIES.filter((c) => c.tags?.includes(tag as NonNullable<Company['tags']>[number]));
+}
+
+/**
+ * Get companies by industry
+ */
+export function getCompaniesByIndustry(industry: string): Company[] {
+  return IRELAND_COMPANIES.filter((c) => c.industry === industry);
+}
+
+/**
+ * Get all company slugs
+ */
+export function getAllCompanySlugs(): string[] {
+  return IRELAND_COMPANIES.map((c) => c.slug);
+}

--- a/src/services/company/company-storage.ts
+++ b/src/services/company/company-storage.ts
@@ -1,0 +1,235 @@
+/**
+ * Company Storage Service
+ *
+ * Handles company data retrieval with Redis caching.
+ * Combines static data with cached external API data.
+ *
+ * Storage schema:
+ * - companies:{slug} -> Company JSON (cached)
+ * - companies:news:{slug} -> News items JSON (cached)
+ */
+
+import type {
+  Company,
+  CompanyFilters,
+  CompanySearchResponse,
+  CompanyNewsItem,
+} from '@/types/company';
+import { COMPANY_LIMITS } from '@/types/company';
+import {
+  IRELAND_COMPANIES,
+  getCompanyBySlug as getStaticCompany,
+  getCompaniesByTag,
+  getCompaniesByIndustry,
+} from '@/data/ireland-companies';
+
+// Redis client (lazy initialization)
+let redisClient: {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, options?: { ex?: number }) => Promise<void>;
+  del: (key: string) => Promise<void>;
+} | null = null;
+
+/**
+ * Initialize Redis client
+ */
+async function getRedis() {
+  if (redisClient) return redisClient;
+
+  const url = typeof process !== 'undefined' ? process.env?.UPSTASH_REDIS_REST_URL : undefined;
+  const token = typeof process !== 'undefined' ? process.env?.UPSTASH_REDIS_REST_TOKEN : undefined;
+
+  if (!url || !token) {
+    console.warn('[CompanyStorage] Redis not configured, using static data only');
+    return null;
+  }
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    redisClient = new Redis({ url, token }) as unknown as typeof redisClient;
+    return redisClient;
+  } catch (e) {
+    console.error('[CompanyStorage] Failed to initialize Redis:', e);
+    return null;
+  }
+}
+
+/**
+ * Storage key helpers
+ */
+const keys = {
+  company: (slug: string) => `companies:${slug}`,
+  news: (slug: string) => `companies:news:${slug}`,
+};
+
+/**
+ * Company Storage class
+ */
+export class CompanyStorage {
+  /**
+   * Get company by slug
+   * Checks cache first, then falls back to static data
+   */
+  async getCompany(slug: string): Promise<Company | null> {
+    // Try cache first
+    const redis = await getRedis();
+    if (redis) {
+      const cached = await redis.get(keys.company(slug));
+      if (cached) {
+        try {
+          return JSON.parse(cached) as Company;
+        } catch {
+          // Fall through to static
+        }
+      }
+    }
+
+    // Fall back to static data
+    return getStaticCompany(slug) || null;
+  }
+
+  /**
+   * Search companies with filters
+   */
+  async searchCompanies(filters: CompanyFilters = {}): Promise<CompanySearchResponse> {
+    let companies = [...IRELAND_COMPANIES];
+
+    // Apply search query
+    if (filters.q) {
+      const q = filters.q.toLowerCase();
+      companies = companies.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          c.description?.toLowerCase().includes(q) ||
+          c.industry.toLowerCase().includes(q)
+      );
+    }
+
+    // Filter by industry
+    if (filters.industry) {
+      companies = companies.filter((c) => c.industry === filters.industry);
+    }
+
+    // Filter by tag
+    if (filters.tag) {
+      companies = companies.filter((c) => c.tags?.includes(filters.tag!));
+    }
+
+    // Filter by location
+    if (filters.location) {
+      const loc = filters.location.toLowerCase();
+      companies = companies.filter((c) =>
+        c.headquarters.toLowerCase().includes(loc)
+      );
+    }
+
+    const total = companies.length;
+
+    // Pagination
+    const offset = filters.offset || 0;
+    const limit = filters.limit || COMPANY_LIMITS.DEFAULT_PAGE_SIZE;
+    companies = companies.slice(offset, offset + limit);
+
+    return { companies, total, filters };
+  }
+
+  /**
+   * Get company news
+   * Returns cached news or empty array
+   */
+  async getCompanyNews(slug: string, limit = 20): Promise<CompanyNewsItem[]> {
+    const redis = await getRedis();
+    if (!redis) return [];
+
+    const cached = await redis.get(keys.news(slug));
+    if (!cached) return [];
+
+    try {
+      const news = JSON.parse(cached) as CompanyNewsItem[];
+      return news.slice(0, limit);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Cache company news
+   */
+  async cacheCompanyNews(slug: string, news: CompanyNewsItem[]): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.news(slug), JSON.stringify(news), {
+      ex: COMPANY_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+
+  /**
+   * Cache company data (for external API results)
+   */
+  async cacheCompany(company: Company): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.company(company.slug), JSON.stringify(company), {
+      ex: COMPANY_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+
+  /**
+   * Get all companies
+   */
+  async getAllCompanies(): Promise<Company[]> {
+    return IRELAND_COMPANIES;
+  }
+
+  /**
+   * Get companies by tag
+   */
+  async getByTag(tag: string): Promise<Company[]> {
+    return getCompaniesByTag(tag);
+  }
+
+  /**
+   * Get companies by industry
+   */
+  async getByIndustry(industry: string): Promise<Company[]> {
+    return getCompaniesByIndustry(industry);
+  }
+
+  /**
+   * Get company count
+   */
+  async getCompanyCount(): Promise<number> {
+    return IRELAND_COMPANIES.length;
+  }
+
+  /**
+   * Get all industries
+   */
+  getIndustries(): string[] {
+    const industries = new Set<string>();
+    for (const company of IRELAND_COMPANIES) {
+      industries.add(company.industry);
+    }
+    return Array.from(industries).sort();
+  }
+
+  /**
+   * Get all tags
+   */
+  getTags(): string[] {
+    const tags = new Set<string>();
+    for (const company of IRELAND_COMPANIES) {
+      if (company.tags) {
+        for (const tag of company.tags) {
+          tags.add(tag);
+        }
+      }
+    }
+    return Array.from(tags).sort();
+  }
+}
+
+// Export singleton
+export const companyStorage = new CompanyStorage();

--- a/src/services/company/index.ts
+++ b/src/services/company/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Company Service
+ *
+ * Manages company profiles for Irish tech ecosystem.
+ */
+
+export { CompanyStorage, companyStorage } from './company-storage';
+export type * from '@/types/company';
+export * from '@/data/ireland-companies';

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,0 +1,208 @@
+/**
+ * Company Types for Company Profile Pages
+ *
+ * Data structures for Irish tech company profiles.
+ */
+
+/** Company industry categories */
+export type CompanyIndustry =
+  | 'Fintech'
+  | 'AI/ML'
+  | 'SaaS'
+  | 'E-commerce'
+  | 'Healthcare'
+  | 'Gaming'
+  | 'Semiconductor'
+  | 'Data Center'
+  | 'Cybersecurity'
+  | 'Cloud'
+  | 'Enterprise'
+  | 'Consumer'
+  | 'Other';
+
+/** Employee count ranges */
+export type EmployeeRange =
+  | '1-10'
+  | '11-50'
+  | '51-200'
+  | '201-500'
+  | '501-1000'
+  | '1001-5000'
+  | '5001-10000'
+  | '10000+';
+
+/** Company tags */
+export type CompanyTag =
+  | 'unicorn'
+  | 'tech-hq'
+  | 'data-center'
+  | 'semiconductor'
+  | 'startup'
+  | 'multinational'
+  | 'irish-founded';
+
+/** Relation type between companies */
+export type CompanyRelation = 'parent' | 'subsidiary' | 'competitor' | 'partner';
+
+/**
+ * Company funding information
+ */
+export interface CompanyFunding {
+  /** Total funding amount */
+  total: string;
+  /** Last funding round type */
+  lastRound?: string;
+  /** Last round date (YYYY-MM) */
+  lastRoundDate?: string;
+  /** Notable investors */
+  investors?: string[];
+}
+
+/**
+ * Key person in the company
+ */
+export interface CompanyPerson {
+  /** Person's name */
+  name: string;
+  /** Job title */
+  title: string;
+  /** LinkedIn profile URL */
+  linkedin?: string;
+  /** Profile image URL */
+  image?: string;
+}
+
+/**
+ * Related company reference
+ */
+export interface RelatedCompany {
+  /** Company slug for linking */
+  slug: string;
+  /** Company name */
+  name: string;
+  /** Relationship type */
+  relation: CompanyRelation;
+}
+
+/**
+ * Complete company profile
+ */
+export interface Company {
+  /** Unique company ID */
+  id: string;
+  /** URL-friendly slug (e.g., "stripe") */
+  slug: string;
+  /** Official company name */
+  name: string;
+  /** Company logo URL */
+  logo?: string;
+  /** Company description */
+  description?: string;
+  /** Year founded */
+  founded?: number;
+  /** Headquarters location */
+  headquarters: string;
+  /** Primary industry */
+  industry: CompanyIndustry;
+  /** Employee count range */
+  employeeCount?: EmployeeRange;
+  /** Official website */
+  website?: string;
+  /** LinkedIn company page */
+  linkedin?: string;
+  /** Twitter/X handle */
+  twitter?: string;
+  /** Funding information */
+  funding?: CompanyFunding;
+  /** Key people */
+  people?: CompanyPerson[];
+  /** Related companies */
+  relatedCompanies?: RelatedCompany[];
+  /** Tags for categorization */
+  tags?: CompanyTag[];
+  /** Map coordinates [longitude, latitude] */
+  coordinates?: [number, number];
+  /** Irish office address */
+  address?: string;
+  /** When data was last updated */
+  updatedAt?: string;
+}
+
+/**
+ * Company news item
+ */
+export interface CompanyNewsItem {
+  /** News article ID */
+  id: string;
+  /** Article title */
+  title: string;
+  /** Article summary */
+  summary: string;
+  /** Article URL */
+  url: string;
+  /** Publication date */
+  publishedAt: string;
+  /** News source */
+  source: string;
+}
+
+/**
+ * Company search filters
+ */
+export interface CompanyFilters {
+  /** Search query (name, description) */
+  q?: string;
+  /** Filter by industry */
+  industry?: CompanyIndustry;
+  /** Filter by tag */
+  tag?: CompanyTag;
+  /** Filter by location */
+  location?: string;
+  /** Pagination offset */
+  offset?: number;
+  /** Pagination limit */
+  limit?: number;
+}
+
+/**
+ * Company search response
+ */
+export interface CompanySearchResponse {
+  /** List of matching companies */
+  companies: Company[];
+  /** Total count */
+  total: number;
+  /** Applied filters */
+  filters: CompanyFilters;
+}
+
+/**
+ * Company API response
+ */
+export interface CompanyResponse {
+  success: boolean;
+  company?: Company;
+  error?: string;
+}
+
+/**
+ * Company news API response
+ */
+export interface CompanyNewsResponse {
+  success: boolean;
+  news?: CompanyNewsItem[];
+  total?: number;
+  error?: string;
+}
+
+// Constants
+export const COMPANY_LIMITS = {
+  /** Maximum companies per search */
+  MAX_SEARCH_RESULTS: 50,
+  /** Default page size */
+  DEFAULT_PAGE_SIZE: 20,
+  /** Maximum news items per company */
+  MAX_NEWS_ITEMS: 50,
+  /** Company cache TTL (1 hour) */
+  CACHE_TTL_SECONDS: 3600,
+};

--- a/tests/company.test.mts
+++ b/tests/company.test.mts
@@ -1,0 +1,358 @@
+/**
+ * Company Service Tests
+ *
+ * Tests for company types, static data, and storage.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+  Company,
+  CompanyFunding,
+  CompanyPerson,
+  RelatedCompany,
+  CompanyFilters,
+  CompanyIndustry,
+  CompanyTag,
+} from '../src/types/company.js';
+import { COMPANY_LIMITS } from '../src/types/company.js';
+import {
+  IRELAND_COMPANIES,
+  getCompanyBySlug,
+  getCompanyById,
+  searchCompanies,
+  getCompaniesByTag,
+  getCompaniesByIndustry,
+  getAllCompanySlugs,
+} from '../src/data/ireland-companies.js';
+
+describe('Company Types', () => {
+  it('Company should have required fields', () => {
+    const company: Company = {
+      id: 'test-company',
+      slug: 'test-company',
+      name: 'Test Company',
+      headquarters: 'Dublin, Ireland',
+      industry: 'Fintech',
+    };
+
+    assert.equal(company.id, 'test-company');
+    assert.equal(company.slug, 'test-company');
+    assert.equal(company.name, 'Test Company');
+    assert.equal(company.headquarters, 'Dublin, Ireland');
+    assert.equal(company.industry, 'Fintech');
+  });
+
+  it('Company should support optional fields', () => {
+    const company: Company = {
+      id: 'full-company',
+      slug: 'full-company',
+      name: 'Full Company',
+      headquarters: 'Cork, Ireland',
+      industry: 'SaaS',
+      description: 'A test company',
+      founded: 2020,
+      employeeCount: '51-200',
+      website: 'https://example.com',
+      funding: {
+        total: '€10M',
+        lastRound: 'Series A',
+      },
+      tags: ['startup', 'irish-founded'],
+    };
+
+    assert.equal(company.description, 'A test company');
+    assert.equal(company.founded, 2020);
+    assert.equal(company.funding?.total, '€10M');
+    assert.deepEqual(company.tags, ['startup', 'irish-founded']);
+  });
+
+  it('CompanyFunding should have required and optional fields', () => {
+    const funding: CompanyFunding = {
+      total: '€100M',
+      lastRound: 'Series B',
+      lastRoundDate: '2025-06',
+      investors: ['Sequoia', 'a16z'],
+    };
+
+    assert.equal(funding.total, '€100M');
+    assert.equal(funding.lastRound, 'Series B');
+    assert.deepEqual(funding.investors, ['Sequoia', 'a16z']);
+  });
+
+  it('CompanyPerson should have required fields', () => {
+    const person: CompanyPerson = {
+      name: 'John Doe',
+      title: 'CEO',
+      linkedin: 'https://linkedin.com/in/johndoe',
+    };
+
+    assert.equal(person.name, 'John Doe');
+    assert.equal(person.title, 'CEO');
+  });
+
+  it('RelatedCompany should have correct structure', () => {
+    const related: RelatedCompany = {
+      slug: 'parent-company',
+      name: 'Parent Company',
+      relation: 'parent',
+    };
+
+    assert.equal(related.slug, 'parent-company');
+    assert.equal(related.relation, 'parent');
+  });
+});
+
+describe('Company Constants', () => {
+  it('COMPANY_LIMITS should have correct values', () => {
+    assert.equal(COMPANY_LIMITS.MAX_SEARCH_RESULTS, 50);
+    assert.equal(COMPANY_LIMITS.DEFAULT_PAGE_SIZE, 20);
+    assert.equal(COMPANY_LIMITS.MAX_NEWS_ITEMS, 50);
+    assert.equal(COMPANY_LIMITS.CACHE_TTL_SECONDS, 3600);
+  });
+});
+
+describe('Static Company Data', () => {
+  it('IRELAND_COMPANIES should not be empty', () => {
+    assert.ok(IRELAND_COMPANIES.length > 0);
+  });
+
+  it('All companies should have required fields', () => {
+    for (const company of IRELAND_COMPANIES) {
+      assert.ok(company.id, `Company missing id: ${JSON.stringify(company)}`);
+      assert.ok(company.slug, `Company missing slug: ${company.id}`);
+      assert.ok(company.name, `Company missing name: ${company.id}`);
+      assert.ok(company.headquarters, `Company missing headquarters: ${company.id}`);
+      assert.ok(company.industry, `Company missing industry: ${company.id}`);
+    }
+  });
+
+  it('All slugs should be unique', () => {
+    const slugs = IRELAND_COMPANIES.map((c) => c.slug);
+    const uniqueSlugs = new Set(slugs);
+    assert.equal(slugs.length, uniqueSlugs.size);
+  });
+
+  it('All IDs should be unique', () => {
+    const ids = IRELAND_COMPANIES.map((c) => c.id);
+    const uniqueIds = new Set(ids);
+    assert.equal(ids.length, uniqueIds.size);
+  });
+
+  it('Coordinates should be valid if present', () => {
+    for (const company of IRELAND_COMPANIES) {
+      if (company.coordinates) {
+        const [lng, lat] = company.coordinates;
+        // Ireland is roughly between -10 to -5 longitude, 51 to 55 latitude
+        assert.ok(lng >= -11 && lng <= -5, `Invalid longitude for ${company.slug}: ${lng}`);
+        assert.ok(lat >= 51 && lat <= 56, `Invalid latitude for ${company.slug}: ${lat}`);
+      }
+    }
+  });
+});
+
+describe('Company Lookup Functions', () => {
+  it('getCompanyBySlug should find existing company', () => {
+    const company = getCompanyBySlug('stripe');
+    assert.ok(company);
+    assert.equal(company.name, 'Stripe');
+  });
+
+  it('getCompanyBySlug should return undefined for non-existent', () => {
+    const company = getCompanyBySlug('non-existent-company');
+    assert.equal(company, undefined);
+  });
+
+  it('getCompanyById should find existing company', () => {
+    const company = getCompanyById('stripe');
+    assert.ok(company);
+    assert.equal(company.slug, 'stripe');
+  });
+
+  it('getCompanyById should return undefined for non-existent', () => {
+    const company = getCompanyById('non-existent');
+    assert.equal(company, undefined);
+  });
+
+  it('getAllCompanySlugs should return all slugs', () => {
+    const slugs = getAllCompanySlugs();
+    assert.equal(slugs.length, IRELAND_COMPANIES.length);
+    assert.ok(slugs.includes('stripe'));
+  });
+});
+
+describe('Company Search Functions', () => {
+  it('searchCompanies should find by name', () => {
+    const results = searchCompanies('stripe');
+    assert.ok(results.length >= 1);
+    assert.ok(results.some((c) => c.slug === 'stripe'));
+  });
+
+  it('searchCompanies should be case-insensitive', () => {
+    const results = searchCompanies('STRIPE');
+    assert.ok(results.length >= 1);
+    assert.ok(results.some((c) => c.slug === 'stripe'));
+  });
+
+  it('searchCompanies should find by industry', () => {
+    const results = searchCompanies('fintech');
+    assert.ok(results.length >= 1);
+    for (const company of results) {
+      assert.ok(
+        company.industry.toLowerCase().includes('fintech') ||
+          company.description?.toLowerCase().includes('fintech')
+      );
+    }
+  });
+
+  it('searchCompanies should return empty for no matches', () => {
+    const results = searchCompanies('xyznonexistent123');
+    assert.equal(results.length, 0);
+  });
+
+  it('getCompaniesByTag should filter correctly', () => {
+    const unicorns = getCompaniesByTag('unicorn');
+    assert.ok(unicorns.length >= 1);
+    for (const company of unicorns) {
+      assert.ok(company.tags?.includes('unicorn'));
+    }
+  });
+
+  it('getCompaniesByIndustry should filter correctly', () => {
+    const semiconductor = getCompaniesByIndustry('Semiconductor');
+    assert.ok(semiconductor.length >= 1);
+    for (const company of semiconductor) {
+      assert.equal(company.industry, 'Semiconductor');
+    }
+  });
+});
+
+describe('Company Filters', () => {
+  function applyFilters(companies: Company[], filters: CompanyFilters): Company[] {
+    let result = [...companies];
+
+    if (filters.q) {
+      const q = filters.q.toLowerCase();
+      result = result.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          c.description?.toLowerCase().includes(q) ||
+          c.industry.toLowerCase().includes(q)
+      );
+    }
+
+    if (filters.industry) {
+      result = result.filter((c) => c.industry === filters.industry);
+    }
+
+    if (filters.tag) {
+      result = result.filter((c) => c.tags?.includes(filters.tag as CompanyTag));
+    }
+
+    if (filters.location) {
+      const loc = filters.location.toLowerCase();
+      result = result.filter((c) => c.headquarters.toLowerCase().includes(loc));
+    }
+
+    return result;
+  }
+
+  it('should filter by industry', () => {
+    const result = applyFilters(IRELAND_COMPANIES, { industry: 'Fintech' });
+    assert.ok(result.length >= 1);
+    for (const c of result) {
+      assert.equal(c.industry, 'Fintech');
+    }
+  });
+
+  it('should filter by tag', () => {
+    const result = applyFilters(IRELAND_COMPANIES, { tag: 'tech-hq' });
+    assert.ok(result.length >= 1);
+    for (const c of result) {
+      assert.ok(c.tags?.includes('tech-hq'));
+    }
+  });
+
+  it('should filter by location', () => {
+    const result = applyFilters(IRELAND_COMPANIES, { location: 'Dublin' });
+    assert.ok(result.length >= 1);
+    for (const c of result) {
+      assert.ok(c.headquarters.toLowerCase().includes('dublin'));
+    }
+  });
+
+  it('should combine multiple filters', () => {
+    const result = applyFilters(IRELAND_COMPANIES, {
+      location: 'Dublin',
+      industry: 'Cloud',
+    });
+    for (const c of result) {
+      assert.ok(c.headquarters.toLowerCase().includes('dublin'));
+      assert.equal(c.industry, 'Cloud');
+    }
+  });
+});
+
+describe('Company Industry Validation', () => {
+  const validIndustries: CompanyIndustry[] = [
+    'Fintech', 'AI/ML', 'SaaS', 'E-commerce', 'Healthcare',
+    'Gaming', 'Semiconductor', 'Data Center', 'Cybersecurity',
+    'Cloud', 'Enterprise', 'Consumer', 'Other',
+  ];
+
+  it('all companies should have valid industry', () => {
+    for (const company of IRELAND_COMPANIES) {
+      assert.ok(
+        validIndustries.includes(company.industry),
+        `Invalid industry "${company.industry}" for ${company.slug}`
+      );
+    }
+  });
+});
+
+describe('Company Tag Validation', () => {
+  const validTags: CompanyTag[] = [
+    'unicorn', 'tech-hq', 'data-center', 'semiconductor',
+    'startup', 'multinational', 'irish-founded',
+  ];
+
+  it('all company tags should be valid', () => {
+    for (const company of IRELAND_COMPANIES) {
+      if (company.tags) {
+        for (const tag of company.tags) {
+          assert.ok(
+            validTags.includes(tag),
+            `Invalid tag "${tag}" for ${company.slug}`
+          );
+        }
+      }
+    }
+  });
+});
+
+describe('Known Companies Spot Check', () => {
+  it('Stripe should exist with correct data', () => {
+    const stripe = getCompanyBySlug('stripe');
+    assert.ok(stripe);
+    assert.equal(stripe.name, 'Stripe');
+    assert.equal(stripe.industry, 'Fintech');
+    assert.ok(stripe.tags?.includes('unicorn'));
+    assert.ok(stripe.tags?.includes('irish-founded'));
+    assert.ok(stripe.funding?.total);
+    assert.ok(stripe.people && stripe.people.length > 0);
+  });
+
+  it('Intel Ireland should exist with correct data', () => {
+    const intel = getCompanyBySlug('intel-ireland');
+    assert.ok(intel);
+    assert.equal(intel.industry, 'Semiconductor');
+    assert.ok(intel.tags?.includes('semiconductor'));
+  });
+
+  it('Google Ireland should exist with correct data', () => {
+    const google = getCompanyBySlug('google-ireland');
+    assert.ok(google);
+    assert.ok(google.tags?.includes('tech-hq'));
+    assert.ok(google.headquarters.includes('Dublin'));
+  });
+});

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -64,6 +64,7 @@ describe('Legacy api/*.js endpoint allowlist', () => {
     'brief.js',
     'briefs.js',
     'cache-purge.js',
+    'companies.js',
     'contact.js',
     'download.js',
     'fwdstart.js',


### PR DESCRIPTION
## Summary

实现公司 Profile 页面系统，支持爱尔兰科技公司详情展示。

### 新增类型 (`src/types/company.ts`)

| 类型 | 描述 |
|------|------|
| `Company` | 完整公司档案 |
| `CompanyFunding` | 融资信息 |
| `CompanyPerson` | 关键人物 |
| `RelatedCompany` | 关联公司 |
| `CompanyIndustry` | 行业枚举 |
| `CompanyTag` | 标签枚举 |

### 静态数据 (`src/data/ireland-companies.ts`)

12 家重点公司：

| 类别 | 公司 |
|------|------|
| Unicorns | Stripe, Intercom |
| Semiconductor | Intel Ireland, Analog Devices |
| Big Tech HQs | Google, Meta, Apple, Microsoft, Amazon |
| Data Centers | Equinix Dublin |
| Fintech | Fenergo |
| Healthcare | ICON plc |

### API 端点 (`api/companies.js`)

| 方法 | 路径 | 描述 |
|------|------|------|
| GET | `/api/companies` | 搜索公司列表 |
| GET | `/api/companies/:slug` | 公司详情 |
| GET | `/api/companies/:slug/news` | 公司新闻 |

**筛选参数**：
- `q`: 关键词搜索
- `industry`: 行业筛选
- `tag`: 标签筛选
- `location`: 地点筛选

### 测试 (31 tests pass)

- ✅ 类型验证
- ✅ 静态数据完整性
- ✅ Slug/ID 唯一性
- ✅ 坐标有效性
- ✅ 搜索功能
- ✅ 筛选逻辑
- ✅ 已知公司数据检查

### 后续工作

- [ ] 前端 CompanyPage 组件
- [ ] 地图标记点击跳转
- [ ] 新闻关联（关键词匹配）
- [ ] 外部 API 集成（Crunchbase/LinkedIn）

Closes #120