### PR TITLE
feat(FR #121): add Trend Dashboard API

### DIFF
--- a/api/trends.js
+++ b/api/trends.js
@@ -1,0 +1,281 @@
+/**
+ * Trends API
+ *
+ * Trend analysis data for Irish tech ecosystem dashboard.
+ * V1 uses mock data with optional Redis caching.
+ *
+ * Routes:
+ * - GET /api/trends/topics - Get trending topics
+ * - GET /api/trends/funding - Get funding trends
+ * - GET /api/trends/industry - Get industry distribution
+ * - GET /api/trends/summary - Get trend summary
+ */
+
+import { jsonResponse } from './_json-response.js';
+import { withCors } from './_cors.js';
+
+// Constants
+const VALID_PERIODS = [30, 90];
+const DEFAULT_PERIOD = 30;
+const DEFAULT_TOPICS = 10;
+const MAX_TOPICS = 20;
+const CACHE_TTL = 3600;
+
+// Redis helpers
+async function redisGet(key) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const cmdUrl = `${url}/get/${encodeURIComponent(key)}`;
+  const resp = await fetch(cmdUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(3000),
+  });
+  if (!resp.ok) return null;
+
+  const data = await resp.json();
+  if (!data.result) return null;
+
+  try {
+    return JSON.parse(data.result);
+  } catch {
+    return null;
+  }
+}
+
+async function redisSetEx(key, seconds, value) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return;
+
+  const cmdUrl = `${url}/setex/${encodeURIComponent(key)}/${seconds}/${encodeURIComponent(JSON.stringify(value))}`;
+  await fetch(cmdUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(3000),
+  }).catch(() => {});
+}
+
+// Helper functions
+function formatCurrency(amount) {
+  if (amount >= 1_000_000_000) return `€${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `€${(amount / 1_000_000).toFixed(0)}M`;
+  if (amount >= 1_000) return `€${(amount / 1_000).toFixed(0)}K`;
+  return `€${amount}`;
+}
+
+function getDateRange(days) {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  return {
+    start: start.toISOString().split('T')[0],
+    end: end.toISOString().split('T')[0],
+  };
+}
+
+// Mock data generators
+function generateTopics(days, limit) {
+  const scale = days === 90 ? 3 : 1;
+  const topics = [
+    { keyword: 'AI', count: 145, change: 25 },
+    { keyword: 'funding', count: 98, change: 12 },
+    { keyword: 'Dublin', count: 87, change: 5 },
+    { keyword: 'fintech', count: 76, change: 18 },
+    { keyword: 'expansion', count: 65, change: -3 },
+    { keyword: 'hiring', count: 58, change: 8 },
+    { keyword: 'semiconductor', count: 52, change: 15 },
+    { keyword: 'startup', count: 48, change: 2 },
+    { keyword: 'cloud', count: 45, change: 10 },
+    { keyword: 'acquisition', count: 42, change: -5 },
+    { keyword: 'data center', count: 38, change: 20 },
+    { keyword: 'EMEA', count: 35, change: 3 },
+    { keyword: 'IPO', count: 28, change: -8 },
+    { keyword: 'unicorn', count: 25, change: 5 },
+    { keyword: 'Cork', count: 22, change: 12 },
+  ];
+
+  return topics.slice(0, limit).map((t) => ({
+    ...t,
+    count: t.count * scale,
+  }));
+}
+
+function generateTimeline(days) {
+  const timeline = [];
+  const end = new Date();
+  const interval = days === 30 ? 1 : 7;
+
+  for (let i = days; i >= 0; i -= interval) {
+    const date = new Date(end);
+    date.setDate(date.getDate() - i);
+    timeline.push({
+      date: date.toISOString().split('T')[0],
+      amount: Math.round(10_000_000 + Math.random() * 90_000_000),
+      deals: Math.floor(1 + Math.random() * 4),
+    });
+  }
+
+  return timeline;
+}
+
+function generateFunding(days) {
+  const timeline = generateTimeline(days);
+  const totalAmount = timeline.reduce((sum, d) => sum + d.amount, 0);
+  const totalDeals = timeline.reduce((sum, d) => sum + d.deals, 0);
+
+  return {
+    total: formatCurrency(totalAmount),
+    deals: totalDeals,
+    averageDealSize: formatCurrency(totalAmount / totalDeals),
+    timeline,
+    weekOverWeek: Math.round(-10 + Math.random() * 30),
+  };
+}
+
+function generateIndustries(days) {
+  const scale = days === 90 ? 3 : 1;
+
+  return [
+    { name: 'Fintech', percentage: 28, newsCount: 120 * scale, fundingAmount: '€180M' },
+    { name: 'AI/ML', percentage: 22, newsCount: 95 * scale, fundingAmount: '€150M' },
+    { name: 'SaaS', percentage: 18, newsCount: 78 * scale, fundingAmount: '€80M' },
+    { name: 'Cloud', percentage: 12, newsCount: 52 * scale, fundingAmount: '€45M' },
+    { name: 'Semiconductor', percentage: 10, newsCount: 43 * scale, fundingAmount: '€120M' },
+    { name: 'Healthcare', percentage: 6, newsCount: 26 * scale, fundingAmount: '€25M' },
+    { name: 'Other', percentage: 4, newsCount: 17 * scale },
+  ];
+}
+
+function generateSummary(days) {
+  const topics = generateTopics(days, 1);
+  const funding = generateFunding(days);
+  const industries = generateIndustries(days);
+  const range = getDateRange(days);
+  const totalNews = industries.reduce((sum, i) => sum + i.newsCount, 0);
+
+  return {
+    totalNews,
+    totalFunding: funding.total,
+    topIndustry: industries[0].name,
+    trendingTopic: topics[0].keyword,
+    weekOverWeek: {
+      news: Math.round(-5 + Math.random() * 20),
+      funding: funding.weekOverWeek,
+    },
+    period: { start: range.start, end: range.end, days },
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// Handler
+async function handler(request) {
+  const reqUrl = new URL(request.url);
+  const method = request.method;
+  const pathParts = reqUrl.pathname.split('/').filter(Boolean);
+
+  if (method !== 'GET') {
+    return jsonResponse({ success: false, error: 'Method not allowed' }, { status: 405 });
+  }
+
+  // Parse period parameter
+  let days = parseInt(reqUrl.searchParams.get('days') || String(DEFAULT_PERIOD), 10);
+  if (!VALID_PERIODS.includes(days)) {
+    days = DEFAULT_PERIOD;
+  }
+
+  const endpoint = pathParts[1] || '';
+
+  try {
+    // GET /api/trends/topics
+    if (endpoint === 'topics') {
+      let limit = parseInt(reqUrl.searchParams.get('limit') || String(DEFAULT_TOPICS), 10);
+      if (limit > MAX_TOPICS) limit = MAX_TOPICS;
+
+      // Try cache
+      const cacheKey = `trends:topics:${days}:${limit}`;
+      const cached = await redisGet(cacheKey);
+      if (cached) {
+        return jsonResponse({
+          success: true,
+          topics: cached,
+          period: getDateRange(days),
+          cached: true,
+        });
+      }
+
+      const topics = generateTopics(days, limit);
+      await redisSetEx(cacheKey, CACHE_TTL, topics);
+
+      return jsonResponse({
+        success: true,
+        topics,
+        period: getDateRange(days),
+      });
+    }
+
+    // GET /api/trends/funding
+    if (endpoint === 'funding') {
+      const cacheKey = `trends:funding:${days}`;
+      const cached = await redisGet(cacheKey);
+      if (cached) {
+        return jsonResponse({ success: true, funding: cached, cached: true });
+      }
+
+      const funding = generateFunding(days);
+      await redisSetEx(cacheKey, CACHE_TTL, funding);
+
+      return jsonResponse({ success: true, funding });
+    }
+
+    // GET /api/trends/industry
+    if (endpoint === 'industry') {
+      const cacheKey = `trends:industry:${days}`;
+      const cached = await redisGet(cacheKey);
+      if (cached) {
+        return jsonResponse({ success: true, industries: cached, cached: true });
+      }
+
+      const industries = generateIndustries(days);
+      await redisSetEx(cacheKey, CACHE_TTL, industries);
+
+      return jsonResponse({ success: true, industries });
+    }
+
+    // GET /api/trends/summary
+    if (endpoint === 'summary') {
+      const cacheKey = `trends:summary:${days}`;
+      const cached = await redisGet(cacheKey);
+      if (cached) {
+        return jsonResponse({ success: true, summary: cached, cached: true });
+      }
+
+      const summary = generateSummary(days);
+      await redisSetEx(cacheKey, CACHE_TTL, summary);
+
+      return jsonResponse({ success: true, summary });
+    }
+
+    // Default: return overview of available endpoints
+    return jsonResponse({
+      success: true,
+      message: 'Trend API',
+      endpoints: [
+        '/api/trends/topics?days=30&limit=10',
+        '/api/trends/funding?days=30',
+        '/api/trends/industry?days=30',
+        '/api/trends/summary?days=30',
+      ],
+      validPeriods: VALID_PERIODS,
+    });
+  } catch (e) {
+    console.error('[trends API] Error:', e);
+    return jsonResponse({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export default withCors(handler);
+
+export const config = {
+  runtime: 'edge',
+};

--- a/src/services/trend/index.ts
+++ b/src/services/trend/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Trend Service
+ *
+ * Trend analysis and aggregation for Irish tech ecosystem.
+ */
+
+export { TrendAggregator, trendAggregator } from './trend-aggregator';
+export { TrendStorage, trendStorage } from './trend-storage';
+export type * from '@/types/trend';

--- a/src/services/trend/trend-aggregator.ts
+++ b/src/services/trend/trend-aggregator.ts
@@ -1,0 +1,187 @@
+/**
+ * Trend Aggregator Service
+ *
+ * Generates trend data for the dashboard.
+ * V1 uses mock data; future versions will aggregate from news DB.
+ */
+
+import type {
+  TrendTopic,
+  FundingTrend,
+  FundingDataPoint,
+  IndustryDistribution,
+  TrendSummary,
+  TrendPeriod,
+} from '@/types/trend';
+import { TREND_LIMITS } from '@/types/trend';
+
+/**
+ * Format currency amount
+ */
+function formatCurrency(amount: number): string {
+  if (amount >= 1_000_000_000) {
+    return `€${(amount / 1_000_000_000).toFixed(1)}B`;
+  }
+  if (amount >= 1_000_000) {
+    return `€${(amount / 1_000_000).toFixed(0)}M`;
+  }
+  if (amount >= 1_000) {
+    return `€${(amount / 1_000).toFixed(0)}K`;
+  }
+  return `€${amount}`;
+}
+
+/**
+ * Get date range for period
+ */
+function getDateRange(days: TrendPeriod): { start: string; end: string } {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+
+  const startDate = start.toISOString().split('T')[0] ?? '';
+  const endDate = end.toISOString().split('T')[0] ?? '';
+
+  return {
+    start: startDate,
+    end: endDate,
+  };
+}
+
+/**
+ * Generate mock timeline data
+ */
+function generateTimeline(days: TrendPeriod): FundingDataPoint[] {
+  const timeline: FundingDataPoint[] = [];
+  const end = new Date();
+  const interval = days === 30 ? 1 : 7; // Daily for 30 days, weekly for 90
+
+  for (let i = days; i >= 0; i -= interval) {
+    const date = new Date(end);
+    date.setDate(date.getDate() - i);
+
+    // Generate realistic-looking random data
+    const baseFunding = 10_000_000 + Math.random() * 90_000_000;
+    const deals = Math.floor(1 + Math.random() * 4);
+
+    timeline.push({
+      date: date.toISOString().split('T')[0] ?? '',
+      amount: Math.round(baseFunding),
+      deals,
+    });
+  }
+
+  return timeline;
+}
+
+/**
+ * Trend Aggregator class
+ */
+export class TrendAggregator {
+  /**
+   * Generate mock topics data
+   * In production, this would extract keywords from news articles
+   */
+  generateTopics(days: TrendPeriod, limit = TREND_LIMITS.DEFAULT_TOPICS): TrendTopic[] {
+    const mockTopics: TrendTopic[] = [
+      { keyword: 'AI', count: 145 + Math.floor(Math.random() * 30), change: 25 },
+      { keyword: 'funding', count: 98 + Math.floor(Math.random() * 20), change: 12 },
+      { keyword: 'Dublin', count: 87 + Math.floor(Math.random() * 15), change: 5 },
+      { keyword: 'fintech', count: 76 + Math.floor(Math.random() * 15), change: 18 },
+      { keyword: 'expansion', count: 65 + Math.floor(Math.random() * 10), change: -3 },
+      { keyword: 'hiring', count: 58 + Math.floor(Math.random() * 10), change: 8 },
+      { keyword: 'semiconductor', count: 52 + Math.floor(Math.random() * 10), change: 15 },
+      { keyword: 'startup', count: 48 + Math.floor(Math.random() * 10), change: 2 },
+      { keyword: 'cloud', count: 45 + Math.floor(Math.random() * 10), change: 10 },
+      { keyword: 'acquisition', count: 42 + Math.floor(Math.random() * 10), change: -5 },
+      { keyword: 'data center', count: 38 + Math.floor(Math.random() * 8), change: 20 },
+      { keyword: 'EMEA', count: 35 + Math.floor(Math.random() * 8), change: 3 },
+      { keyword: 'IPO', count: 28 + Math.floor(Math.random() * 5), change: -8 },
+      { keyword: 'unicorn', count: 25 + Math.floor(Math.random() * 5), change: 5 },
+      { keyword: 'Cork', count: 22 + Math.floor(Math.random() * 5), change: 12 },
+    ];
+
+    // Scale counts based on period
+    const scale = days === 90 ? 3 : 1;
+
+    return mockTopics.slice(0, limit).map((t) => ({
+      ...t,
+      count: t.count * scale,
+    }));
+  }
+
+  /**
+   * Generate mock funding trend data
+   */
+  generateFundingTrend(days: TrendPeriod): FundingTrend {
+    const timeline = generateTimeline(days);
+
+    // Calculate totals
+    const totalAmount = timeline.reduce((sum, d) => sum + d.amount, 0);
+    const totalDeals = timeline.reduce((sum, d) => sum + d.deals, 0);
+
+    return {
+      total: formatCurrency(totalAmount),
+      deals: totalDeals,
+      averageDealSize: formatCurrency(totalAmount / totalDeals),
+      timeline,
+      weekOverWeek: Math.round(-10 + Math.random() * 30), // -10% to +20%
+    };
+  }
+
+  /**
+   * Generate mock industry distribution
+   */
+  generateIndustryDistribution(days: TrendPeriod): IndustryDistribution[] {
+    const scale = days === 90 ? 3 : 1;
+
+    return [
+      { name: 'Fintech', percentage: 28, newsCount: 120 * scale, fundingAmount: '€180M' },
+      { name: 'AI/ML', percentage: 22, newsCount: 95 * scale, fundingAmount: '€150M' },
+      { name: 'SaaS', percentage: 18, newsCount: 78 * scale, fundingAmount: '€80M' },
+      { name: 'Cloud', percentage: 12, newsCount: 52 * scale, fundingAmount: '€45M' },
+      { name: 'Semiconductor', percentage: 10, newsCount: 43 * scale, fundingAmount: '€120M' },
+      { name: 'Healthcare', percentage: 6, newsCount: 26 * scale, fundingAmount: '€25M' },
+      { name: 'Other', percentage: 4, newsCount: 17 * scale },
+    ];
+  }
+
+  /**
+   * Generate summary
+   */
+  generateSummary(days: TrendPeriod): TrendSummary {
+    const topics = this.generateTopics(days, 1);
+    const funding = this.generateFundingTrend(days);
+    const industries = this.generateIndustryDistribution(days);
+    const range = getDateRange(days);
+
+    const totalNews = industries.reduce((sum, i) => sum + i.newsCount, 0);
+
+    return {
+      totalNews,
+      totalFunding: funding.total,
+      topIndustry: industries[0]?.name ?? 'Unknown',
+      trendingTopic: topics[0]?.keyword ?? 'Unknown',
+      weekOverWeek: {
+        news: Math.round(-5 + Math.random() * 20),
+        funding: funding.weekOverWeek,
+      },
+      period: {
+        start: range.start,
+        end: range.end,
+        days,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Validate period parameter
+   */
+  isValidPeriod(days: number): days is TrendPeriod {
+    return TREND_LIMITS.VALID_PERIODS.includes(days as TrendPeriod);
+  }
+}
+
+// Export singleton
+export const trendAggregator = new TrendAggregator();

--- a/src/services/trend/trend-storage.ts
+++ b/src/services/trend/trend-storage.ts
@@ -1,0 +1,183 @@
+/**
+ * Trend Storage Service
+ *
+ * Handles caching of trend data in Redis.
+ * Storage schema:
+ * - trends:topics:{days} -> Topics JSON
+ * - trends:funding:{days} -> Funding JSON
+ * - trends:industry:{days} -> Industry JSON
+ * - trends:summary:{days} -> Summary JSON
+ */
+
+import type {
+  TrendTopic,
+  FundingTrend,
+  IndustryDistribution,
+  TrendSummary,
+  TrendPeriod,
+} from '@/types/trend';
+import { TREND_LIMITS } from '@/types/trend';
+
+// Redis client (lazy initialization)
+let redisClient: {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, options?: { ex?: number }) => Promise<void>;
+} | null = null;
+
+/**
+ * Initialize Redis client
+ */
+async function getRedis() {
+  if (redisClient) return redisClient;
+
+  const url = typeof process !== 'undefined' ? process.env?.UPSTASH_REDIS_REST_URL : undefined;
+  const token = typeof process !== 'undefined' ? process.env?.UPSTASH_REDIS_REST_TOKEN : undefined;
+
+  if (!url || !token) {
+    console.warn('[TrendStorage] Redis not configured');
+    return null;
+  }
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    redisClient = new Redis({ url, token }) as unknown as typeof redisClient;
+    return redisClient;
+  } catch (e) {
+    console.error('[TrendStorage] Failed to initialize Redis:', e);
+    return null;
+  }
+}
+
+/**
+ * Storage key helpers
+ */
+const keys = {
+  topics: (days: TrendPeriod) => `trends:topics:${days}`,
+  funding: (days: TrendPeriod) => `trends:funding:${days}`,
+  industry: (days: TrendPeriod) => `trends:industry:${days}`,
+  summary: (days: TrendPeriod) => `trends:summary:${days}`,
+};
+
+/**
+ * Trend Storage class
+ */
+export class TrendStorage {
+  /**
+   * Get cached topics
+   */
+  async getTopics(days: TrendPeriod): Promise<TrendTopic[] | null> {
+    const redis = await getRedis();
+    if (!redis) return null;
+
+    const data = await redis.get(keys.topics(days));
+    if (!data) return null;
+
+    try {
+      return JSON.parse(data) as TrendTopic[];
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Cache topics
+   */
+  async setTopics(days: TrendPeriod, topics: TrendTopic[]): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.topics(days), JSON.stringify(topics), {
+      ex: TREND_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+
+  /**
+   * Get cached funding trend
+   */
+  async getFunding(days: TrendPeriod): Promise<FundingTrend | null> {
+    const redis = await getRedis();
+    if (!redis) return null;
+
+    const data = await redis.get(keys.funding(days));
+    if (!data) return null;
+
+    try {
+      return JSON.parse(data) as FundingTrend;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Cache funding trend
+   */
+  async setFunding(days: TrendPeriod, funding: FundingTrend): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.funding(days), JSON.stringify(funding), {
+      ex: TREND_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+
+  /**
+   * Get cached industry distribution
+   */
+  async getIndustry(days: TrendPeriod): Promise<IndustryDistribution[] | null> {
+    const redis = await getRedis();
+    if (!redis) return null;
+
+    const data = await redis.get(keys.industry(days));
+    if (!data) return null;
+
+    try {
+      return JSON.parse(data) as IndustryDistribution[];
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Cache industry distribution
+   */
+  async setIndustry(days: TrendPeriod, industries: IndustryDistribution[]): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.industry(days), JSON.stringify(industries), {
+      ex: TREND_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+
+  /**
+   * Get cached summary
+   */
+  async getSummary(days: TrendPeriod): Promise<TrendSummary | null> {
+    const redis = await getRedis();
+    if (!redis) return null;
+
+    const data = await redis.get(keys.summary(days));
+    if (!data) return null;
+
+    try {
+      return JSON.parse(data) as TrendSummary;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Cache summary
+   */
+  async setSummary(days: TrendPeriod, summary: TrendSummary): Promise<void> {
+    const redis = await getRedis();
+    if (!redis) return;
+
+    await redis.set(keys.summary(days), JSON.stringify(summary), {
+      ex: TREND_LIMITS.CACHE_TTL_SECONDS,
+    });
+  }
+}
+
+// Export singleton
+export const trendStorage = new TrendStorage();

--- a/src/types/trend.ts
+++ b/src/types/trend.ts
@@ -1,0 +1,173 @@
+/**
+ * Trend Types for Trend Dashboard
+ *
+ * Data structures for trend analysis and visualization.
+ */
+
+/** Time period for trend analysis */
+export type TrendPeriod = 30 | 90;
+
+/**
+ * Topic/keyword trend item
+ */
+export interface TrendTopic {
+  /** Keyword/topic */
+  keyword: string;
+  /** Occurrence count */
+  count: number;
+  /** Change from previous period (percentage) */
+  change: number;
+  /** Sentiment score (-1 to 1) */
+  sentiment?: number;
+}
+
+/**
+ * Funding timeline data point
+ */
+export interface FundingDataPoint {
+  /** Date (YYYY-MM-DD) */
+  date: string;
+  /** Funding amount in EUR */
+  amount: number;
+  /** Number of deals */
+  deals: number;
+}
+
+/**
+ * Funding trend data
+ */
+export interface FundingTrend {
+  /** Total funding in period */
+  total: string;
+  /** Total number of deals */
+  deals: number;
+  /** Average deal size */
+  averageDealSize: string;
+  /** Timeline data for chart */
+  timeline: FundingDataPoint[];
+  /** Week-over-week change percentage */
+  weekOverWeek: number;
+}
+
+/**
+ * Industry distribution item
+ */
+export interface IndustryDistribution {
+  /** Industry name */
+  name: string;
+  /** Percentage of total */
+  percentage: number;
+  /** News article count */
+  newsCount: number;
+  /** Funding amount if available */
+  fundingAmount?: string;
+}
+
+/**
+ * M&A activity data
+ */
+export interface MATrend {
+  /** Total M&A deals */
+  totalDeals: number;
+  /** Total deal value */
+  totalValue: string;
+  /** Deals by month */
+  timeline: Array<{
+    month: string;
+    deals: number;
+    value: number;
+  }>;
+}
+
+/**
+ * Trend summary for dashboard
+ */
+export interface TrendSummary {
+  /** Total news articles in period */
+  totalNews: number;
+  /** Total funding amount */
+  totalFunding: string;
+  /** Most active industry */
+  topIndustry: string;
+  /** Most trending topic */
+  trendingTopic: string;
+  /** Week-over-week changes */
+  weekOverWeek: {
+    news: number;
+    funding: number;
+  };
+  /** Period analyzed */
+  period: {
+    start: string;
+    end: string;
+    days: TrendPeriod;
+  };
+  /** Last updated timestamp */
+  updatedAt: string;
+}
+
+/**
+ * Topics API response
+ */
+export interface TopicsResponse {
+  success: boolean;
+  topics?: TrendTopic[];
+  period?: { start: string; end: string };
+  error?: string;
+}
+
+/**
+ * Funding API response
+ */
+export interface FundingResponse {
+  success: boolean;
+  funding?: FundingTrend;
+  error?: string;
+}
+
+/**
+ * Industry API response
+ */
+export interface IndustryResponse {
+  success: boolean;
+  industries?: IndustryDistribution[];
+  error?: string;
+}
+
+/**
+ * Summary API response
+ */
+export interface SummaryResponse {
+  success: boolean;
+  summary?: TrendSummary;
+  error?: string;
+}
+
+// Constants
+export const TREND_LIMITS = {
+  /** Maximum topics to return */
+  MAX_TOPICS: 20,
+  /** Default topics count */
+  DEFAULT_TOPICS: 10,
+  /** Cache TTL (1 hour) */
+  CACHE_TTL_SECONDS: 3600,
+  /** Valid periods */
+  VALID_PERIODS: [30, 90] as const,
+};
+
+/**
+ * Common tech keywords for topic extraction
+ */
+export const TECH_KEYWORDS = [
+  'AI', 'artificial intelligence', 'machine learning', 'ML',
+  'funding', 'investment', 'venture capital', 'VC',
+  'acquisition', 'merger', 'M&A', 'IPO',
+  'startup', 'unicorn', 'scale-up',
+  'fintech', 'healthtech', 'biotech', 'cleantech',
+  'cloud', 'SaaS', 'data center',
+  'semiconductor', 'chip', 'manufacturing',
+  'hiring', 'jobs', 'layoffs', 'expansion',
+  'revenue', 'growth', 'profit',
+  'Dublin', 'Cork', 'Galway', 'Ireland',
+  'EMEA', 'Europe', 'headquarters',
+];

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -85,6 +85,7 @@ describe('Legacy api/*.js endpoint allowlist', () => {
     'seed-health.js',
     'story.js',
     'telegram-feed.js',
+    'trends.js',
     'version.js',
   ]);
 

--- a/tests/trend.test.mts
+++ b/tests/trend.test.mts
@@ -1,0 +1,315 @@
+/**
+ * Trend Service Tests
+ *
+ * Tests for trend types, aggregation, and data generation.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+  TrendTopic,
+  FundingTrend,
+  FundingDataPoint,
+  IndustryDistribution,
+  TrendSummary,
+  TrendPeriod,
+} from '../src/types/trend.js';
+import { TREND_LIMITS, TECH_KEYWORDS } from '../src/types/trend.js';
+import { TrendAggregator } from '../src/services/trend/trend-aggregator.js';
+
+describe('Trend Types', () => {
+  it('TrendTopic should have required fields', () => {
+    const topic: TrendTopic = {
+      keyword: 'AI',
+      count: 145,
+      change: 25,
+    };
+
+    assert.equal(topic.keyword, 'AI');
+    assert.equal(topic.count, 145);
+    assert.equal(topic.change, 25);
+  });
+
+  it('FundingDataPoint should have required fields', () => {
+    const dataPoint: FundingDataPoint = {
+      date: '2026-03-24',
+      amount: 50000000,
+      deals: 3,
+    };
+
+    assert.equal(dataPoint.date, '2026-03-24');
+    assert.equal(dataPoint.amount, 50000000);
+    assert.equal(dataPoint.deals, 3);
+  });
+
+  it('FundingTrend should have required fields', () => {
+    const funding: FundingTrend = {
+      total: '€450M',
+      deals: 12,
+      averageDealSize: '€37.5M',
+      timeline: [],
+      weekOverWeek: 15,
+    };
+
+    assert.equal(funding.total, '€450M');
+    assert.equal(funding.deals, 12);
+    assert.equal(funding.averageDealSize, '€37.5M');
+    assert.ok(Array.isArray(funding.timeline));
+  });
+
+  it('IndustryDistribution should have required fields', () => {
+    const industry: IndustryDistribution = {
+      name: 'Fintech',
+      percentage: 28,
+      newsCount: 120,
+      fundingAmount: '€180M',
+    };
+
+    assert.equal(industry.name, 'Fintech');
+    assert.equal(industry.percentage, 28);
+    assert.equal(industry.newsCount, 120);
+  });
+
+  it('TrendSummary should have required fields', () => {
+    const summary: TrendSummary = {
+      totalNews: 450,
+      totalFunding: '€450M',
+      topIndustry: 'Fintech',
+      trendingTopic: 'AI',
+      weekOverWeek: { news: 15, funding: 10 },
+      period: { start: '2026-02-24', end: '2026-03-24', days: 30 },
+      updatedAt: '2026-03-24T00:00:00Z',
+    };
+
+    assert.equal(summary.totalNews, 450);
+    assert.equal(summary.topIndustry, 'Fintech');
+    assert.equal(summary.period.days, 30);
+  });
+});
+
+describe('Trend Constants', () => {
+  it('TREND_LIMITS should have correct values', () => {
+    assert.equal(TREND_LIMITS.MAX_TOPICS, 20);
+    assert.equal(TREND_LIMITS.DEFAULT_TOPICS, 10);
+    assert.equal(TREND_LIMITS.CACHE_TTL_SECONDS, 3600);
+    assert.deepEqual(TREND_LIMITS.VALID_PERIODS, [30, 90]);
+  });
+
+  it('TECH_KEYWORDS should contain common keywords', () => {
+    assert.ok(TECH_KEYWORDS.includes('AI'));
+    assert.ok(TECH_KEYWORDS.includes('funding'));
+    assert.ok(TECH_KEYWORDS.includes('Dublin'));
+    assert.ok(TECH_KEYWORDS.includes('fintech'));
+    assert.ok(TECH_KEYWORDS.includes('semiconductor'));
+  });
+});
+
+describe('TrendAggregator', () => {
+  const aggregator = new TrendAggregator();
+
+  describe('generateTopics', () => {
+    it('should generate topics for 30-day period', () => {
+      const topics = aggregator.generateTopics(30);
+
+      assert.equal(topics.length, TREND_LIMITS.DEFAULT_TOPICS);
+      for (const topic of topics) {
+        assert.ok(topic.keyword);
+        assert.ok(typeof topic.count === 'number');
+        assert.ok(typeof topic.change === 'number');
+      }
+    });
+
+    it('should generate topics for 90-day period with scaled counts', () => {
+      const topics30 = aggregator.generateTopics(30);
+      const topics90 = aggregator.generateTopics(90);
+
+      // 90-day counts should be roughly 3x the 30-day counts
+      assert.ok(topics90[0].count > topics30[0].count);
+    });
+
+    it('should respect limit parameter', () => {
+      const topics5 = aggregator.generateTopics(30, 5);
+      const topics15 = aggregator.generateTopics(30, 15);
+
+      assert.equal(topics5.length, 5);
+      assert.equal(topics15.length, 15);
+    });
+
+    it('should have AI as top topic', () => {
+      const topics = aggregator.generateTopics(30);
+      assert.equal(topics[0].keyword, 'AI');
+    });
+  });
+
+  describe('generateFundingTrend', () => {
+    it('should generate funding trend for 30-day period', () => {
+      const funding = aggregator.generateFundingTrend(30);
+
+      assert.ok(funding.total.startsWith('€'));
+      assert.ok(funding.deals > 0);
+      assert.ok(funding.averageDealSize.startsWith('€'));
+      assert.ok(funding.timeline.length > 0);
+      assert.ok(typeof funding.weekOverWeek === 'number');
+    });
+
+    it('should have valid timeline dates', () => {
+      const funding = aggregator.generateFundingTrend(30);
+
+      for (const point of funding.timeline) {
+        assert.match(point.date, /^\d{4}-\d{2}-\d{2}$/);
+        assert.ok(point.amount > 0);
+        assert.ok(point.deals >= 1);
+      }
+    });
+
+    it('should have more timeline points for 30-day vs 90-day', () => {
+      const funding30 = aggregator.generateFundingTrend(30);
+      const funding90 = aggregator.generateFundingTrend(90);
+
+      // 30-day is daily (31 points), 90-day is weekly (13 points)
+      assert.ok(funding30.timeline.length > funding90.timeline.length);
+    });
+  });
+
+  describe('generateIndustryDistribution', () => {
+    it('should generate industry distribution', () => {
+      const industries = aggregator.generateIndustryDistribution(30);
+
+      assert.ok(industries.length > 0);
+      for (const industry of industries) {
+        assert.ok(industry.name);
+        assert.ok(industry.percentage > 0);
+        assert.ok(industry.newsCount > 0);
+      }
+    });
+
+    it('should have Fintech as top industry', () => {
+      const industries = aggregator.generateIndustryDistribution(30);
+      assert.equal(industries[0].name, 'Fintech');
+    });
+
+    it('should have percentages summing to ~100', () => {
+      const industries = aggregator.generateIndustryDistribution(30);
+      const total = industries.reduce((sum, i) => sum + i.percentage, 0);
+      assert.equal(total, 100);
+    });
+
+    it('should scale news counts for 90-day period', () => {
+      const industries30 = aggregator.generateIndustryDistribution(30);
+      const industries90 = aggregator.generateIndustryDistribution(90);
+
+      // 90-day counts should be 3x
+      assert.equal(industries90[0].newsCount, industries30[0].newsCount * 3);
+    });
+  });
+
+  describe('generateSummary', () => {
+    it('should generate summary for 30-day period', () => {
+      const summary = aggregator.generateSummary(30);
+
+      assert.ok(summary.totalNews > 0);
+      assert.ok(summary.totalFunding.startsWith('€'));
+      assert.ok(summary.topIndustry);
+      assert.ok(summary.trendingTopic);
+      assert.ok(summary.weekOverWeek);
+      assert.equal(summary.period.days, 30);
+      assert.ok(summary.updatedAt);
+    });
+
+    it('should have valid date range', () => {
+      const summary = aggregator.generateSummary(30);
+
+      assert.match(summary.period.start, /^\d{4}-\d{2}-\d{2}$/);
+      assert.match(summary.period.end, /^\d{4}-\d{2}-\d{2}$/);
+
+      const start = new Date(summary.period.start);
+      const end = new Date(summary.period.end);
+      const diffDays = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+
+      assert.ok(diffDays >= 29 && diffDays <= 31);
+    });
+
+    it('should have AI as trending topic', () => {
+      const summary = aggregator.generateSummary(30);
+      assert.equal(summary.trendingTopic, 'AI');
+    });
+  });
+
+  describe('isValidPeriod', () => {
+    it('should accept valid periods', () => {
+      assert.ok(aggregator.isValidPeriod(30));
+      assert.ok(aggregator.isValidPeriod(90));
+    });
+
+    it('should reject invalid periods', () => {
+      assert.ok(!aggregator.isValidPeriod(7));
+      assert.ok(!aggregator.isValidPeriod(60));
+      assert.ok(!aggregator.isValidPeriod(365));
+    });
+  });
+});
+
+describe('Currency Formatting', () => {
+  function formatCurrency(amount: number): string {
+    if (amount >= 1_000_000_000) return `€${(amount / 1_000_000_000).toFixed(1)}B`;
+    if (amount >= 1_000_000) return `€${(amount / 1_000_000).toFixed(0)}M`;
+    if (amount >= 1_000) return `€${(amount / 1_000).toFixed(0)}K`;
+    return `€${amount}`;
+  }
+
+  it('should format billions', () => {
+    assert.equal(formatCurrency(2_500_000_000), '€2.5B');
+    assert.equal(formatCurrency(1_000_000_000), '€1.0B');
+  });
+
+  it('should format millions', () => {
+    assert.equal(formatCurrency(450_000_000), '€450M');
+    assert.equal(formatCurrency(1_500_000), '€2M');
+  });
+
+  it('should format thousands', () => {
+    assert.equal(formatCurrency(500_000), '€500K');
+    assert.equal(formatCurrency(50_000), '€50K');
+  });
+
+  it('should format small amounts', () => {
+    assert.equal(formatCurrency(999), '€999');
+    assert.equal(formatCurrency(0), '€0');
+  });
+});
+
+describe('Date Range Calculation', () => {
+  function getDateRange(days: number): { start: string; end: string } {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - days);
+    return {
+      start: start.toISOString().split('T')[0],
+      end: end.toISOString().split('T')[0],
+    };
+  }
+
+  it('should calculate 30-day range', () => {
+    const range = getDateRange(30);
+    const start = new Date(range.start);
+    const end = new Date(range.end);
+    const diff = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+
+    assert.ok(diff >= 29 && diff <= 31);
+  });
+
+  it('should calculate 90-day range', () => {
+    const range = getDateRange(90);
+    const start = new Date(range.start);
+    const end = new Date(range.end);
+    const diff = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+
+    assert.ok(diff >= 89 && diff <= 91);
+  });
+
+  it('should return valid date format', () => {
+    const range = getDateRange(30);
+    assert.match(range.start, /^\d{4}-\d{2}-\d{2}$/);
+    assert.match(range.end, /^\d{4}-\d{2}-\d{2}$/);
+  });
+});


### PR DESCRIPTION
## Summary

实现趋势分析看板 API，支持热门话题、融资趋势、行业分布等数据可视化。

### 新增类型 (`src/types/trend.ts`)

| 类型 | 描述 |
|------|------|
| `TrendTopic` | 关键词/话题（含计数和变化率） |
| `FundingTrend` | 融资趋势（含时间线） |
| `FundingDataPoint` | 融资数据点 |
| `IndustryDistribution` | 行业分布 |
| `TrendSummary` | 看板摘要 |

### 新增服务 (`src/services/trend/`)

**TrendAggregator**:
- `generateTopics()`: 热门关键词 Top N
- `generateFundingTrend()`: 融资时间线
- `generateIndustryDistribution()`: 行业占比
- `generateSummary()`: 综合摘要

**TrendStorage**:
- Redis 缓存（1 小时 TTL）

### API 端点 (`api/trends.js`)

| 方法 | 路径 | 描述 |
|------|------|------|
| GET | `/api/trends/topics?days=30&limit=10` | 热门话题 |
| GET | `/api/trends/funding?days=30` | 融资趋势 |
| GET | `/api/trends/industry?days=30` | 行业分布 |
| GET | `/api/trends/summary?days=30` | 综合摘要 |

**支持周期**：30 天、90 天

### 测试 (30 tests pass)

- ✅ 类型验证
- ✅ 常量检查
- ✅ 话题生成（含周期缩放）
- ✅ 融资趋势（含时间线）
- ✅ 行业分布（百分比验证）
- ✅ 摘要生成
- ✅ 周期验证
- ✅ 货币格式化
- ✅ 日期范围计算

### V1 说明

当前使用模拟数据，后续可接入真实新闻数据库聚合。

Closes #121