### PR TITLE
feat(FR #128): implement glowing circle markers with animation

### DIFF
--- a/src/services/marker-icons.ts
+++ b/src/services/marker-icons.ts
@@ -2,11 +2,18 @@
  * Marker Icons Service
  *
  * Provides icon definitions for deck.gl IconLayer.
- * Uses inline SVG data URLs for reliable rendering.
+ * Uses inline SVG data URLs with glowing effects for worldmonitor-style appearance.
+ *
+ * Design principles:
+ * - All markers are circles (unified visual language)
+ * - Tier 1: Large (24px) with radial gradient glow
+ * - Tier 2: Medium (16px) with subtle glow
+ * - Tier 3: Small (12px) minimal glow
  */
 
 import type { MarkerTier } from './marker-tier';
 
+// Keep MarkerShape for backwards compatibility, but all shapes map to circle
 export type MarkerShape = 'circle' | 'diamond' | 'triangle' | 'square';
 
 /**
@@ -23,50 +30,86 @@ export interface IconDefinition {
 
 /**
  * Get icon name based on shape and tier
+ * Note: All shapes now use circle icons for unified design
  */
-export function getMarkerIconName(shape: MarkerShape, tier: MarkerTier): string {
+export function getMarkerIconName(_shape: MarkerShape, tier: MarkerTier): string {
   const sizeLabel = tier === 1 ? 'large' : tier === 2 ? 'medium' : 'small';
-  return `${shape}-${sizeLabel}`;
+  return `circle-${sizeLabel}`;
 }
 
 /**
  * Get icon size based on tier
+ * Tier 1 icons are larger to accommodate glow effect
  */
 export function getMarkerSizeForTier(tier: MarkerTier, _shape: MarkerShape = 'circle'): number {
-  return tier === 1 ? 24 : tier === 2 ? 16 : 12;
+  // Tier 1 needs extra space for glow effect
+  return tier === 1 ? 48 : tier === 2 ? 32 : 24;
 }
 
 /**
- * SVG path definitions for each shape
- * All shapes are white filled for mask coloring
- *
- * Shapes (4 total - simplified design):
- * - circle: Core infrastructure (Semiconductor Hubs, Data Centers)
- * - diamond: Professional/HQ (Tech HQs, Accelerators)
- * - triangle: Growth/Unicorns (Irish Unicorns)
- * - square: Foundation (Cloud Regions)
+ * Generate glowing circle SVG data URL
+ * Uses radial gradient and multiple layers for glow effect
  */
-const SVG_PATHS: Record<MarkerShape, string> = {
-  circle: 'M12 2 A10 10 0 1 0 12 22 A10 10 0 1 0 12 2',
-  diamond: 'M12 2 L22 12 L12 22 L2 12 Z',
-  triangle: 'M12 3 L22 21 L2 21 Z',
-  square: 'M3 3 H21 V21 H3 Z',
-};
+function generateGlowingCircleSvg(tier: MarkerTier): string {
+  if (tier === 1) {
+    // Tier 1: Large circle with full glow effect + animation-ready
+    // Size: 48x48 to accommodate glow
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+      <defs>
+        <radialGradient id="glow1" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="white" stop-opacity="1"/>
+          <stop offset="50%" stop-color="white" stop-opacity="0.6"/>
+          <stop offset="100%" stop-color="white" stop-opacity="0"/>
+        </radialGradient>
+        <filter id="blur1" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="3" result="blur"/>
+          <feMerge>
+            <feMergeNode in="blur"/>
+            <feMergeNode in="SourceGraphic"/>
+          </feMerge>
+        </filter>
+      </defs>
+      <!-- Outer glow layer (most transparent) -->
+      <circle cx="24" cy="24" r="20" fill="url(#glow1)" opacity="0.3"/>
+      <!-- Middle glow layer -->
+      <circle cx="24" cy="24" r="14" fill="url(#glow1)" opacity="0.5"/>
+      <!-- Core circle with glow filter -->
+      <circle cx="24" cy="24" r="10" fill="white" opacity="0.9" filter="url(#blur1)"/>
+    </svg>`;
+  } else if (tier === 2) {
+    // Tier 2: Medium circle with subtle glow
+    // Size: 32x32
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+      <defs>
+        <radialGradient id="glow2" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="white" stop-opacity="1"/>
+          <stop offset="70%" stop-color="white" stop-opacity="0.4"/>
+          <stop offset="100%" stop-color="white" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+      <!-- Subtle outer glow -->
+      <circle cx="16" cy="16" r="12" fill="url(#glow2)" opacity="0.4"/>
+      <!-- Core circle -->
+      <circle cx="16" cy="16" r="6" fill="white" opacity="0.85"/>
+    </svg>`;
+  } else {
+    // Tier 3: Small circle with minimal glow
+    // Size: 24x24
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+      <!-- Minimal glow layer -->
+      <circle cx="12" cy="12" r="8" fill="white" opacity="0.3"/>
+      <!-- Core circle -->
+      <circle cx="12" cy="12" r="4" fill="white" opacity="0.8"/>
+    </svg>`;
+  }
+}
 
 /**
- * Generate SVG data URL for a shape
- * Uses semi-transparent fill (0.85 opacity) for worldmonitor-style appearance
+ * Generate SVG data URL for a glowing circle marker
  */
-function generateSvgDataUrl(shape: MarkerShape, size: number): string {
-  const path = SVG_PATHS[shape];
-  // Scale path to fit size (original paths are designed for 24x24)
-  const scale = size / 24;
-  // Semi-transparent fill for cleaner, more professional look (worldmonitor style)
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24">
-    <g transform="scale(${scale})">
-      <path d="${path}" fill="white" fill-opacity="0.85"/>
-    </g>
-  </svg>`;
+function generateSvgDataUrl(_shape: MarkerShape, tier: MarkerTier): string {
+  // All shapes use circle with glow effect
+  const svg = generateGlowingCircleSvg(tier);
   return `data:image/svg+xml;base64,${btoa(svg)}`;
 }
 
@@ -79,18 +122,20 @@ const ICON_CACHE: Record<string, IconDefinition> = {};
 /**
  * Get cached icon definition for a specific shape and tier
  * Returns the same object reference for the same parameters
+ * Note: All shapes now render as glowing circles
  */
 export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinition {
-  const key = `${shape}-${tier}`;
+  // All shapes use the same circle icon per tier
+  const key = `circle-${tier}`;
   if (!ICON_CACHE[key]) {
     const size = getMarkerSizeForTier(tier, shape);
     ICON_CACHE[key] = {
       id: key,
-      url: generateSvgDataUrl(shape, size),
+      url: generateSvgDataUrl(shape, tier),
       width: size,
       height: size,
       mask: true,
-      anchorY: size,
+      anchorY: size / 2, // Center anchor for better glow effect
     };
   }
   return ICON_CACHE[key];
@@ -98,28 +143,58 @@ export function getMarkerIcon(shape: MarkerShape, tier: MarkerTier): IconDefinit
 
 /**
  * Icon mapping for IconLayer (legacy format, kept for tests)
+ * Updated sizes to match new glowing circle dimensions
  */
 export const MARKER_ICON_MAPPING: Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> = {
-  'circle-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'circle-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'circle-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  'diamond-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'diamond-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'diamond-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  'triangle-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'triangle-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'triangle-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
-  'square-small': { x: 0, y: 0, width: 12, height: 12, mask: true },
-  'square-medium': { x: 0, y: 0, width: 16, height: 16, mask: true },
-  'square-large': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  // All shapes now map to circle icons with glow-appropriate sizes
+  'circle-small': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  'circle-medium': { x: 0, y: 0, width: 32, height: 32, mask: true },
+  'circle-large': { x: 0, y: 0, width: 48, height: 48, mask: true },
+  // Legacy shape names kept for backwards compatibility (all render as circles)
+  'diamond-small': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  'diamond-medium': { x: 0, y: 0, width: 32, height: 32, mask: true },
+  'diamond-large': { x: 0, y: 0, width: 48, height: 48, mask: true },
+  'triangle-small': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  'triangle-medium': { x: 0, y: 0, width: 32, height: 32, mask: true },
+  'triangle-large': { x: 0, y: 0, width: 48, height: 48, mask: true },
+  'square-small': { x: 0, y: 0, width: 24, height: 24, mask: true },
+  'square-medium': { x: 0, y: 0, width: 32, height: 32, mask: true },
+  'square-large': { x: 0, y: 0, width: 48, height: 48, mask: true },
 };
 
 /**
  * Get icon URL for a specific shape and tier
+ * Note: All shapes return circle icon URLs
  */
-export function getMarkerIconUrl(shape: MarkerShape, tier: MarkerTier): string {
-  const iconName = getMarkerIconName(shape, tier);
-  return `/icons/map-markers/${iconName}.svg`;
+export function getMarkerIconUrl(_shape: MarkerShape, tier: MarkerTier): string {
+  const sizeLabel = tier === 1 ? 'large' : tier === 2 ? 'medium' : 'small';
+  return `/icons/map-markers/circle-${sizeLabel}.svg`;
 }
 
+/**
+ * Layer color palette (worldmonitor-inspired)
+ * High saturation colors for better visibility with glow effects
+ */
+export const LAYER_COLORS = {
+  // Core infrastructure - Purple tones
+  semiconductorHubs: [168, 85, 247] as [number, number, number], // #A855F7
+  dataCenters: [147, 51, 234] as [number, number, number],       // #9333EA
 
+  // Tech HQs - Blue tones
+  techHQs: [14, 165, 233] as [number, number, number],           // #0EA5E9
+
+  // Unicorns & Startups - Warm tones
+  irishUnicorns: [249, 115, 22] as [number, number, number],     // #F97316
+  startupHubs: [239, 68, 68] as [number, number, number],        // #EF4444
+  accelerators: [236, 72, 153] as [number, number, number],      // #EC4899
+
+  // Cloud infrastructure - Teal
+  cloudRegions: [20, 184, 166] as [number, number, number],      // #14B8A6
+};
+
+/**
+ * Get color for a layer type
+ */
+export function getLayerColor(layerType: keyof typeof LAYER_COLORS): [number, number, number] {
+  return LAYER_COLORS[layerType] || [128, 128, 128];
+}

--- a/src/styles/map-markers.css
+++ b/src/styles/map-markers.css
@@ -1,0 +1,107 @@
+/**
+ * Map Marker Styles
+ *
+ * Defines glowing circle markers with pulse animation.
+ * Animation only applies to Tier 1 markers for performance.
+ */
+
+/* Pulse animation for Tier 1 markers */
+@keyframes marker-pulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+}
+
+/* Tier 1 markers - Large with pulse animation */
+.marker-tier1 {
+  animation: marker-pulse 2.5s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+/* Tier 2 markers - Medium, static */
+.marker-tier2 {
+  opacity: 0.8;
+}
+
+/* Tier 3 markers - Small, static */
+.marker-tier3 {
+  opacity: 0.7;
+}
+
+/* Alternative: If using deck.gl transitions */
+.deck-gl-marker.tier-1 {
+  transition: transform 0.3s ease-out;
+}
+
+.deck-gl-marker.tier-1:hover {
+  transform: scale(1.2);
+}
+
+/* Legend marker styles */
+.legend-marker {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+/* Glowing legend marker */
+.legend-marker.glow {
+  box-shadow: 
+    0 0 4px currentColor,
+    0 0 8px currentColor;
+}
+
+/* Layer colors for legend */
+.legend-marker.semiconductor-hubs {
+  background-color: #A855F7;
+  color: #A855F7;
+}
+
+.legend-marker.data-centers {
+  background-color: #9333EA;
+  color: #9333EA;
+}
+
+.legend-marker.tech-hqs {
+  background-color: #0EA5E9;
+  color: #0EA5E9;
+}
+
+.legend-marker.irish-unicorns {
+  background-color: #F97316;
+  color: #F97316;
+}
+
+.legend-marker.startup-hubs {
+  background-color: #EF4444;
+  color: #EF4444;
+}
+
+.legend-marker.accelerators {
+  background-color: #EC4899;
+  color: #EC4899;
+}
+
+.legend-marker.cloud-regions {
+  background-color: #14B8A6;
+  color: #14B8A6;
+}
+
+/* Reduce motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .marker-tier1 {
+    animation: none;
+  }
+  
+  .deck-gl-marker.tier-1:hover {
+    transform: none;
+  }
+}

--- a/tests/marker-icons.test.mts
+++ b/tests/marker-icons.test.mts
@@ -1,186 +1,209 @@
 /**
- * Marker Icons Service Tests
+ * Marker Icons Tests
  *
- * Tests for simplified marker shapes (FR #107):
- * - circle: Core infrastructure (Semiconductor Hubs, Data Centers)
- * - diamond: Professional/HQ (Tech HQs, Accelerators)
- * - triangle: Growth/Unicorns (Irish Unicorns)
- * - square: Foundation (Cloud Regions)
+ * Tests for glowing circle marker icons.
  */
+
 import { describe, it } from 'node:test';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import {
   getMarkerIconName,
   getMarkerSizeForTier,
-  getMarkerIconUrl,
   getMarkerIcon,
+  getMarkerIconUrl,
+  getLayerColor,
   MARKER_ICON_MAPPING,
-  type MarkerShape,
-} from '../src/services/marker-icons.ts';
-import type { MarkerTier } from '../src/services/marker-tier.ts';
+  LAYER_COLORS,
+} from '../src/services/marker-icons.js';
+import type { MarkerShape } from '../src/services/marker-icons.js';
 
-describe('Marker Icons Service', () => {
-  describe('getMarkerIconName', () => {
-    it('returns correct name for circle shape', () => {
-      assert.equal(getMarkerIconName('circle', 1), 'circle-large');
-      assert.equal(getMarkerIconName('circle', 2), 'circle-medium');
-      assert.equal(getMarkerIconName('circle', 3), 'circle-small');
-    });
-
-    it('returns correct name for diamond shape', () => {
-      assert.equal(getMarkerIconName('diamond', 1), 'diamond-large');
-      assert.equal(getMarkerIconName('diamond', 2), 'diamond-medium');
-      assert.equal(getMarkerIconName('diamond', 3), 'diamond-small');
-    });
-
-    it('returns correct name for triangle shape', () => {
-      assert.equal(getMarkerIconName('triangle', 1), 'triangle-large');
-      assert.equal(getMarkerIconName('triangle', 2), 'triangle-medium');
-      assert.equal(getMarkerIconName('triangle', 3), 'triangle-small');
-    });
-
-    it('returns correct name for square shape', () => {
-      assert.equal(getMarkerIconName('square', 1), 'square-large');
-      assert.equal(getMarkerIconName('square', 2), 'square-medium');
-      assert.equal(getMarkerIconName('square', 3), 'square-small');
-    });
+describe('Marker Icon Names', () => {
+  it('should return circle icon name for all shapes', () => {
+    // All shapes now use circle icons
+    assert.equal(getMarkerIconName('circle', 1), 'circle-large');
+    assert.equal(getMarkerIconName('diamond', 1), 'circle-large');
+    assert.equal(getMarkerIconName('triangle', 1), 'circle-large');
+    assert.equal(getMarkerIconName('square', 1), 'circle-large');
   });
 
-  describe('getMarkerSizeForTier', () => {
-    it('returns correct sizes for all tiers', () => {
-      assert.equal(getMarkerSizeForTier(1, 'circle'), 24);
-      assert.equal(getMarkerSizeForTier(2, 'circle'), 16);
-      assert.equal(getMarkerSizeForTier(3, 'circle'), 12);
-    });
+  it('should return correct size label for each tier', () => {
+    assert.equal(getMarkerIconName('circle', 1), 'circle-large');
+    assert.equal(getMarkerIconName('circle', 2), 'circle-medium');
+    assert.equal(getMarkerIconName('circle', 3), 'circle-small');
+  });
+});
 
-    it('returns same sizes for all shapes (simplified design)', () => {
-      const shapes: MarkerShape[] = ['circle', 'diamond', 'triangle', 'square'];
-      for (const shape of shapes) {
-        assert.equal(getMarkerSizeForTier(1, shape), 24, `Tier 1 ${shape} should be 24px`);
-        assert.equal(getMarkerSizeForTier(2, shape), 16, `Tier 2 ${shape} should be 16px`);
-        assert.equal(getMarkerSizeForTier(3, shape), 12, `Tier 3 ${shape} should be 12px`);
+describe('Marker Sizes', () => {
+  it('should return larger sizes for glow effect', () => {
+    // Tier 1 is 48px to accommodate glow
+    assert.equal(getMarkerSizeForTier(1), 48);
+    // Tier 2 is 32px
+    assert.equal(getMarkerSizeForTier(2), 32);
+    // Tier 3 is 24px
+    assert.equal(getMarkerSizeForTier(3), 24);
+  });
+
+  it('should return same size regardless of shape', () => {
+    const shapes: MarkerShape[] = ['circle', 'diamond', 'triangle', 'square'];
+    for (const shape of shapes) {
+      assert.equal(getMarkerSizeForTier(1, shape), 48);
+      assert.equal(getMarkerSizeForTier(2, shape), 32);
+      assert.equal(getMarkerSizeForTier(3, shape), 24);
+    }
+  });
+});
+
+describe('Marker Icon Definition', () => {
+  it('should return valid icon definition for tier 1', () => {
+    const icon = getMarkerIcon('circle', 1);
+
+    assert.ok(icon.id);
+    assert.ok(icon.url.startsWith('data:image/svg+xml;base64,'));
+    assert.equal(icon.width, 48);
+    assert.equal(icon.height, 48);
+    assert.equal(icon.mask, true);
+    assert.equal(icon.anchorY, 24); // Center anchor
+  });
+
+  it('should return valid icon definition for tier 2', () => {
+    const icon = getMarkerIcon('circle', 2);
+
+    assert.equal(icon.width, 32);
+    assert.equal(icon.height, 32);
+    assert.equal(icon.anchorY, 16);
+  });
+
+  it('should return valid icon definition for tier 3', () => {
+    const icon = getMarkerIcon('circle', 3);
+
+    assert.equal(icon.width, 24);
+    assert.equal(icon.height, 24);
+    assert.equal(icon.anchorY, 12);
+  });
+
+  it('should return same icon for all shapes (unified circles)', () => {
+    const circleIcon = getMarkerIcon('circle', 1);
+    const diamondIcon = getMarkerIcon('diamond', 1);
+    const triangleIcon = getMarkerIcon('triangle', 1);
+    const squareIcon = getMarkerIcon('square', 1);
+
+    // All shapes return the same circle icon
+    assert.equal(circleIcon.id, diamondIcon.id);
+    assert.equal(circleIcon.id, triangleIcon.id);
+    assert.equal(circleIcon.id, squareIcon.id);
+  });
+
+  it('should cache icon definitions', () => {
+    const icon1 = getMarkerIcon('circle', 1);
+    const icon2 = getMarkerIcon('circle', 1);
+
+    // Same object reference (cached)
+    assert.equal(icon1, icon2);
+  });
+});
+
+describe('Icon URL', () => {
+  it('should return circle SVG URL for all shapes', () => {
+    assert.equal(getMarkerIconUrl('circle', 1), '/icons/map-markers/circle-large.svg');
+    assert.equal(getMarkerIconUrl('diamond', 1), '/icons/map-markers/circle-large.svg');
+    assert.equal(getMarkerIconUrl('triangle', 2), '/icons/map-markers/circle-medium.svg');
+    assert.equal(getMarkerIconUrl('square', 3), '/icons/map-markers/circle-small.svg');
+  });
+});
+
+describe('Icon Mapping', () => {
+  it('should have updated sizes for glow effect', () => {
+    // Tier 1 (large) should be 48x48
+    assert.equal(MARKER_ICON_MAPPING['circle-large'].width, 48);
+    assert.equal(MARKER_ICON_MAPPING['circle-large'].height, 48);
+
+    // Tier 2 (medium) should be 32x32
+    assert.equal(MARKER_ICON_MAPPING['circle-medium'].width, 32);
+    assert.equal(MARKER_ICON_MAPPING['circle-medium'].height, 32);
+
+    // Tier 3 (small) should be 24x24
+    assert.equal(MARKER_ICON_MAPPING['circle-small'].width, 24);
+    assert.equal(MARKER_ICON_MAPPING['circle-small'].height, 24);
+  });
+
+  it('should have all legacy shape names', () => {
+    const shapes = ['circle', 'diamond', 'triangle', 'square'];
+    const sizes = ['small', 'medium', 'large'];
+
+    for (const shape of shapes) {
+      for (const size of sizes) {
+        const key = `${shape}-${size}`;
+        assert.ok(MARKER_ICON_MAPPING[key], `Missing mapping for ${key}`);
+        assert.equal(MARKER_ICON_MAPPING[key].mask, true);
       }
-    });
+    }
+  });
+});
 
-    it('uses circle size when shape not specified', () => {
-      assert.equal(getMarkerSizeForTier(1), 24);
-      assert.equal(getMarkerSizeForTier(2), 16);
-      assert.equal(getMarkerSizeForTier(3), 12);
-    });
+describe('Layer Colors', () => {
+  it('should have all layer colors defined', () => {
+    assert.ok(LAYER_COLORS.semiconductorHubs);
+    assert.ok(LAYER_COLORS.dataCenters);
+    assert.ok(LAYER_COLORS.techHQs);
+    assert.ok(LAYER_COLORS.irishUnicorns);
+    assert.ok(LAYER_COLORS.startupHubs);
+    assert.ok(LAYER_COLORS.accelerators);
+    assert.ok(LAYER_COLORS.cloudRegions);
   });
 
-  describe('getMarkerIconUrl', () => {
-    it('returns correct URL path', () => {
-      assert.equal(getMarkerIconUrl('circle', 1), '/icons/map-markers/circle-large.svg');
-      assert.equal(getMarkerIconUrl('diamond', 2), '/icons/map-markers/diamond-medium.svg');
-      assert.equal(getMarkerIconUrl('triangle', 3), '/icons/map-markers/triangle-small.svg');
-      assert.equal(getMarkerIconUrl('square', 1), '/icons/map-markers/square-large.svg');
-    });
+  it('should return RGB tuple format', () => {
+    const color = LAYER_COLORS.semiconductorHubs;
+    assert.equal(color.length, 3);
+    assert.ok(color[0] >= 0 && color[0] <= 255);
+    assert.ok(color[1] >= 0 && color[1] <= 255);
+    assert.ok(color[2] >= 0 && color[2] <= 255);
   });
 
-  describe('MARKER_ICON_MAPPING', () => {
-    it('has all 12 icon mappings (4 shapes × 3 tiers)', () => {
-      assert.equal(Object.keys(MARKER_ICON_MAPPING).length, 12);
-    });
-
-    it('has correct dimensions for all icons', () => {
-      const shapes: MarkerShape[] = ['circle', 'diamond', 'triangle', 'square'];
-      const sizes = ['small', 'medium', 'large'];
-
-      for (const shape of shapes) {
-        for (const size of sizes) {
-          const key = `${shape}-${size}`;
-          const mapping = MARKER_ICON_MAPPING[key];
-          assert.ok(mapping, `Missing mapping for ${key}`);
-          assert.ok(mapping.width > 0, `${key} should have positive width`);
-          assert.ok(mapping.height > 0, `${key} should have positive height`);
-          assert.equal(mapping.mask, true, `${key} should have mask=true for color tinting`);
-        }
-      }
-    });
-
-    it('all large icons have same size (simplified design)', () => {
-      assert.equal(MARKER_ICON_MAPPING['circle-large']?.width, 24);
-      assert.equal(MARKER_ICON_MAPPING['diamond-large']?.width, 24);
-      assert.equal(MARKER_ICON_MAPPING['triangle-large']?.width, 24);
-      assert.equal(MARKER_ICON_MAPPING['square-large']?.width, 24);
-    });
+  it('getLayerColor should return correct color', () => {
+    assert.deepEqual(getLayerColor('semiconductorHubs'), [168, 85, 247]);
+    assert.deepEqual(getLayerColor('dataCenters'), [147, 51, 234]);
+    assert.deepEqual(getLayerColor('techHQs'), [14, 165, 233]);
+    assert.deepEqual(getLayerColor('irishUnicorns'), [249, 115, 22]);
   });
 
-  describe('getMarkerIcon', () => {
-    it('returns cached icon definition with correct properties', () => {
-      const icon = getMarkerIcon('circle', 1);
-      assert.ok(icon.url.startsWith('data:image/svg+xml;base64,'), 'URL should be a data URL');
-      assert.equal(icon.width, 24);
-      assert.equal(icon.height, 24);
-      assert.equal(icon.mask, true);
-    });
+  it('getLayerColor should return gray for unknown layer', () => {
+    // @ts-expect-error - Testing invalid layer type
+    const color = getLayerColor('unknownLayer');
+    assert.deepEqual(color, [128, 128, 128]);
+  });
+});
 
-    it('returns same object reference for same parameters (caching)', () => {
-      const icon1 = getMarkerIcon('diamond', 2);
-      const icon2 = getMarkerIcon('diamond', 2);
-      assert.strictEqual(icon1, icon2, 'Should return same cached object');
-    });
+describe('SVG Data URL', () => {
+  it('tier 1 icon should contain glow filter', () => {
+    const icon = getMarkerIcon('circle', 1);
+    const svg = atob(icon.url.replace('data:image/svg+xml;base64,', ''));
 
-    it('returns different objects for different parameters', () => {
-      const icon1 = getMarkerIcon('triangle', 1);
-      const icon2 = getMarkerIcon('triangle', 2);
-      assert.notStrictEqual(icon1, icon2);
-    });
-
-    it('all tier 1 icons have same dimensions (simplified design)', () => {
-      const circleIcon = getMarkerIcon('circle', 1);
-      const diamondIcon = getMarkerIcon('diamond', 1);
-      const triangleIcon = getMarkerIcon('triangle', 1);
-      const squareIcon = getMarkerIcon('square', 1);
-      assert.equal(circleIcon.width, 24);
-      assert.equal(diamondIcon.width, 24);
-      assert.equal(triangleIcon.width, 24);
-      assert.equal(squareIcon.width, 24);
-    });
-
-    it('generates valid SVG data URL for circle', () => {
-      const icon = getMarkerIcon('circle', 1);
-      const base64Part = icon.url.replace('data:image/svg+xml;base64,', '');
-      const decoded = atob(base64Part);
-      assert.ok(decoded.includes('<svg'), 'Should contain SVG element');
-      assert.ok(decoded.includes('<path') || decoded.includes('A10 10'), 'Should contain circle path');
-      assert.ok(decoded.includes('fill="white"'), 'Should have white fill for masking');
-    });
-
-    it('generates valid SVG data URL for triangle', () => {
-      const icon = getMarkerIcon('triangle', 1);
-      const base64Part = icon.url.replace('data:image/svg+xml;base64,', '');
-      const decoded = atob(base64Part);
-      assert.ok(decoded.includes('<svg'), 'Should contain SVG element');
-      assert.ok(decoded.includes('<path'), 'Should contain path element');
-      assert.ok(decoded.includes('fill="white"'), 'Should have white fill for masking');
-    });
+    assert.ok(svg.includes('radialGradient'));
+    assert.ok(svg.includes('feGaussianBlur'));
+    assert.ok(svg.includes('filter'));
   });
 
-  describe('Shape usage guidelines (FR #107)', () => {
-    it('circle is valid for core infrastructure layers', () => {
-      // Semiconductor Hubs, Data Centers, Startup Hubs
-      const icon = getMarkerIcon('circle', 1);
-      assert.ok(icon, 'Circle should be available');
-    });
+  it('tier 2 icon should contain radial gradient', () => {
+    const icon = getMarkerIcon('circle', 2);
+    const svg = atob(icon.url.replace('data:image/svg+xml;base64,', ''));
 
-    it('diamond is valid for professional/HQ layers', () => {
-      // Tech HQs, Accelerators
-      const icon = getMarkerIcon('diamond', 1);
-      assert.ok(icon, 'Diamond should be available');
-    });
+    assert.ok(svg.includes('radialGradient'));
+  });
 
-    it('triangle is valid for growth/unicorn layers', () => {
-      // Irish Unicorns
-      const icon = getMarkerIcon('triangle', 1);
-      assert.ok(icon, 'Triangle should be available');
-    });
+  it('tier 3 icon should be simple circles', () => {
+    const icon = getMarkerIcon('circle', 3);
+    const svg = atob(icon.url.replace('data:image/svg+xml;base64,', ''));
 
-    it('square is valid for foundation layers', () => {
-      // Cloud Regions
-      const icon = getMarkerIcon('square', 1);
-      assert.ok(icon, 'Square should be available');
-    });
+    assert.ok(svg.includes('<circle'));
+    // Tier 3 doesn't need heavy filters
+    assert.ok(!svg.includes('feGaussianBlur'));
+  });
+
+  it('all icons should use white fill for mask coloring', () => {
+    for (let tier = 1; tier <= 3; tier++) {
+      const icon = getMarkerIcon('circle', tier as 1 | 2 | 3);
+      const svg = atob(icon.url.replace('data:image/svg+xml;base64,', ''));
+      assert.ok(svg.includes('white'), `Tier ${tier} should use white fill`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

实现发光圆形地图标记，模仿 worldmonitor.com 的视觉效果。

### 设计原则

- **统一圆形**：所有图层使用相同的圆形标记
- **三层 Tier**：大/中/小 对应不同的发光强度
- **GPU 优化**：使用 CSS transform 和 will-change

### 视觉效果

**Tier 1 (48px)**:
- 径向渐变（中心 100% → 边缘 0%）
- 高斯模糊滤镜
- 三层光晕叠加
- 脉冲动画（2.5s 周期）

**Tier 2 (32px)**:
- 轻微径向渐变
- 静态显示

**Tier 3 (24px)**:
- 最小光晕
- 静态显示

### 颜色方案

| 图层 | 颜色 | Hex |
|------|------|-----|
| Semiconductor Hubs | 紫 | #A855F7 |
| Data Centers | 深紫 | #9333EA |
| Tech HQs | 青蓝 | #0EA5E9 |
| Irish Unicorns | 橙 | #F97316 |
| Startup Hubs | 红 | #EF4444 |
| Accelerators | 粉 | #EC4899 |
| Cloud Regions | 青绿 | #14B8A6 |

### 改动

**src/services/marker-icons.ts**:
- 统一所有形状为圆形
- 新增发光 SVG 生成（radialGradient + blur filter）
- 新增 `LAYER_COLORS` 常量
- 新增 `getLayerColor()` 函数

**src/styles/map-markers.css**:
- Tier 1 脉冲动画
- Legend 样式
- prefers-reduced-motion 支持

### 测试 (20 tests pass)

- ✅ 图标名称统一
- ✅ 尺寸验证
- ✅ 图标缓存
- ✅ 颜色配置
- ✅ SVG 内容验证

Closes #128