### PR TITLE
feat(FR #133): Friendly News Panel Titles with Emoji

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -3,6 +3,7 @@ import type { AppContext, AppModule } from '@/app/app-context';
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
+import { getPanelTitleConfig } from '@/constants/panelTitles';
 import {
   MapContainer,
   NewsPanel,
@@ -616,7 +617,11 @@ export class PanelLayoutManager implements AppModule {
       if (this.ctx.panels[panelKey]) continue;
       if (!DEFAULT_PANELS[panelKey] && !DEFAULT_PANELS[key]) continue;
       const panelConfig = DEFAULT_PANELS[panelKey] ?? DEFAULT_PANELS[key];
-      const label = panelConfig?.name ?? key.charAt(0).toUpperCase() + key.slice(1);
+      // Use friendly panel title with emoji if available
+      const titleConfig = getPanelTitleConfig(key, SITE_VARIANT);
+      const label = titleConfig
+        ? `${titleConfig.emoji} ${titleConfig.title}`
+        : panelConfig?.name ?? key.charAt(0).toUpperCase() + key.slice(1);
       const panel = new NewsPanel(panelKey, label);
       this.attachRelatedAssetHandlers(panel);
       this.ctx.newsPanels[key] = panel;

--- a/src/constants/panelTitles.ts
+++ b/src/constants/panelTitles.ts
@@ -1,0 +1,146 @@
+/**
+ * Panel Titles Configuration
+ *
+ * Friendly panel title mappings with emoji and count display.
+ * Used across all variants for consistent panel header formatting.
+ */
+
+export interface PanelTitleConfig {
+  /** Emoji icon for the panel */
+  emoji: string;
+  /** Full title for desktop */
+  title: string;
+  /** Short title for mobile (optional, falls back to title) */
+  shortTitle?: string;
+}
+
+/**
+ * Panel title configurations for Ireland variant
+ */
+export const IRELAND_PANEL_TITLES: Record<string, PanelTitleConfig> = {
+  ieTech: {
+    emoji: '🇮🇪',
+    title: 'Irish Tech News',
+    shortTitle: 'Irish Tech',
+  },
+  ieAcademic: {
+    emoji: '🎓',
+    title: 'Academic Research',
+    shortTitle: 'Academia',
+  },
+  ieSemiconductors: {
+    emoji: '💎',
+    title: 'Semiconductor Industry',
+    shortTitle: 'Semiconductors',
+  },
+  ieDeals: {
+    emoji: '🏢',
+    title: 'Tech M&A',
+    shortTitle: 'M&A',
+  },
+  ieJobs: {
+    emoji: '💼',
+    title: 'Big Tech Jobs',
+    shortTitle: 'Jobs',
+  },
+  startups: {
+    emoji: '🚀',
+    title: 'Startups & VC',
+    shortTitle: 'Startups',
+  },
+  ieSummits: {
+    emoji: '🎤',
+    title: 'Tech Summits',
+    shortTitle: 'Summits',
+  },
+  ieBusiness: {
+    emoji: '📊',
+    title: 'Business News',
+    shortTitle: 'Business',
+  },
+  ai: {
+    emoji: '🤖',
+    title: 'AI/ML Updates',
+    shortTitle: 'AI/ML',
+  },
+};
+
+/**
+ * Default panel titles for other variants (fallback)
+ */
+export const DEFAULT_PANEL_TITLES: Record<string, PanelTitleConfig> = {
+  politics: { emoji: '🌍', title: 'World News', shortTitle: 'World' },
+  tech: { emoji: '💻', title: 'Technology', shortTitle: 'Tech' },
+  finance: { emoji: '📈', title: 'Financial', shortTitle: 'Finance' },
+  ai: { emoji: '🤖', title: 'AI/ML Updates', shortTitle: 'AI/ML' },
+  startups: { emoji: '🚀', title: 'Startups & VC', shortTitle: 'Startups' },
+  security: { emoji: '🔒', title: 'Cybersecurity', shortTitle: 'Security' },
+  hardware: { emoji: '💎', title: 'Semiconductors & Hardware', shortTitle: 'Hardware' },
+  cloud: { emoji: '☁️', title: 'Cloud & Infrastructure', shortTitle: 'Cloud' },
+  dev: { emoji: '👨‍💻', title: 'Developer Community', shortTitle: 'Dev' },
+  github: { emoji: '🐙', title: 'GitHub Trending', shortTitle: 'GitHub' },
+  funding: { emoji: '💰', title: 'Funding & VC', shortTitle: 'Funding' },
+  layoffs: { emoji: '📉', title: 'Layoffs Tracker', shortTitle: 'Layoffs' },
+  ipo: { emoji: '📋', title: 'IPO & SPAC', shortTitle: 'IPO' },
+  producthunt: { emoji: '🏆', title: 'Product Hunt', shortTitle: 'PH' },
+  crypto: { emoji: '₿', title: 'Crypto', shortTitle: 'Crypto' },
+  energy: { emoji: '⚡', title: 'Energy & Resources', shortTitle: 'Energy' },
+  intel: { emoji: '🔍', title: 'Intel Feed', shortTitle: 'Intel' },
+  gov: { emoji: '🏛️', title: 'Government', shortTitle: 'Gov' },
+  middleeast: { emoji: '🕌', title: 'Middle East', shortTitle: 'MENA' },
+  africa: { emoji: '🌍', title: 'Africa', shortTitle: 'Africa' },
+  latam: { emoji: '🌎', title: 'Latin America', shortTitle: 'LatAm' },
+  asia: { emoji: '🌏', title: 'Asia-Pacific', shortTitle: 'APAC' },
+  thinktanks: { emoji: '🧠', title: 'Think Tanks', shortTitle: 'Think Tanks' },
+  policy: { emoji: '📜', title: 'AI Policy & Regulation', shortTitle: 'Policy' },
+  vcblogs: { emoji: '📝', title: 'VC Insights & Essays', shortTitle: 'VC Blogs' },
+  regionalStartups: { emoji: '🌐', title: 'Global Startup News', shortTitle: 'Global' },
+  unicorns: { emoji: '🦄', title: 'Unicorn Tracker', shortTitle: 'Unicorns' },
+  accelerators: { emoji: '🎯', title: 'Accelerators & Demo Days', shortTitle: 'Accelerators' },
+};
+
+/**
+ * Get panel title config for a given panel ID
+ * @param panelId - Panel identifier
+ * @param variant - Site variant (optional, defaults to checking Ireland first)
+ * @returns Panel title config or undefined if not found
+ */
+export function getPanelTitleConfig(
+  panelId: string,
+  variant?: string
+): PanelTitleConfig | undefined {
+  // Check variant-specific config first
+  if (variant === 'ireland' || IRELAND_PANEL_TITLES[panelId]) {
+    const irelandConfig = IRELAND_PANEL_TITLES[panelId];
+    if (irelandConfig) return irelandConfig;
+  }
+
+  // Fall back to default titles
+  return DEFAULT_PANEL_TITLES[panelId];
+}
+
+/**
+ * Format panel title with emoji and count
+ * @param panelId - Panel identifier
+ * @param count - Number of items (optional)
+ * @param isMobile - Whether to use short title
+ * @param variant - Site variant
+ * @returns Formatted title string
+ */
+export function formatPanelTitle(
+  panelId: string,
+  count?: number,
+  isMobile = false,
+  variant?: string
+): string {
+  const config = getPanelTitleConfig(panelId, variant);
+  if (!config) {
+    // Fallback: capitalize panel ID
+    const title = panelId.charAt(0).toUpperCase() + panelId.slice(1);
+    return count !== undefined ? `${title} (${count})` : title;
+  }
+
+  const title = isMobile && config.shortTitle ? config.shortTitle : config.title;
+  const formatted = `${config.emoji} ${title}`;
+  return count !== undefined ? `${formatted} (${count})` : formatted;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1391,9 +1391,9 @@ body.panel-resize-active iframe {
 .panel-title {
   font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.5px;
   color: var(--text);
+  /* Remove text-transform: uppercase to support friendly titles with emoji */
 }
 
 /* Push the first element after header-left to the right; subsequent siblings flow via gap */

--- a/tests/panel-titles.test.mts
+++ b/tests/panel-titles.test.mts
@@ -1,0 +1,225 @@
+/**
+ * Panel Titles Tests
+ *
+ * Tests for friendly panel title mappings with emoji.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  IRELAND_PANEL_TITLES,
+  DEFAULT_PANEL_TITLES,
+  getPanelTitleConfig,
+  formatPanelTitle,
+} from '../src/constants/panelTitles';
+
+// ==============================================================
+// Ireland Panel Titles Tests
+// ==============================================================
+
+describe('Ireland panel titles', () => {
+  it('should define all expected Ireland panels', () => {
+    const expectedPanels = [
+      'ieTech',
+      'ieAcademic',
+      'ieSemiconductors',
+      'ieDeals',
+      'ieJobs',
+      'startups',
+      'ieSummits',
+      'ieBusiness',
+      'ai',
+    ];
+
+    expectedPanels.forEach(panelId => {
+      assert.ok(IRELAND_PANEL_TITLES[panelId], `Missing panel title for ${panelId}`);
+    });
+  });
+
+  it('each Ireland panel should have emoji and title', () => {
+    for (const [panelId, config] of Object.entries(IRELAND_PANEL_TITLES)) {
+      assert.ok(config.emoji, `Missing emoji for ${panelId}`);
+      assert.ok(config.title, `Missing title for ${panelId}`);
+      assert.ok(config.emoji.length > 0, `Empty emoji for ${panelId}`);
+      assert.ok(config.title.length > 0, `Empty title for ${panelId}`);
+    }
+  });
+
+  it('should have correct emoji mappings', () => {
+    assert.equal(IRELAND_PANEL_TITLES.ieTech?.emoji, '🇮🇪');
+    assert.equal(IRELAND_PANEL_TITLES.ieAcademic?.emoji, '🎓');
+    assert.equal(IRELAND_PANEL_TITLES.ieSemiconductors?.emoji, '💎');
+    assert.equal(IRELAND_PANEL_TITLES.ieDeals?.emoji, '🏢');
+    assert.equal(IRELAND_PANEL_TITLES.ieJobs?.emoji, '💼');
+    assert.equal(IRELAND_PANEL_TITLES.startups?.emoji, '🚀');
+    assert.equal(IRELAND_PANEL_TITLES.ieSummits?.emoji, '🎤');
+    assert.equal(IRELAND_PANEL_TITLES.ieBusiness?.emoji, '📊');
+    assert.equal(IRELAND_PANEL_TITLES.ai?.emoji, '🤖');
+  });
+
+  it('should have correct title mappings', () => {
+    assert.equal(IRELAND_PANEL_TITLES.ieTech?.title, 'Irish Tech News');
+    assert.equal(IRELAND_PANEL_TITLES.ieAcademic?.title, 'Academic Research');
+    assert.equal(IRELAND_PANEL_TITLES.ieSemiconductors?.title, 'Semiconductor Industry');
+    assert.equal(IRELAND_PANEL_TITLES.ieDeals?.title, 'Tech M&A');
+    assert.equal(IRELAND_PANEL_TITLES.ieJobs?.title, 'Big Tech Jobs');
+    assert.equal(IRELAND_PANEL_TITLES.startups?.title, 'Startups & VC');
+    assert.equal(IRELAND_PANEL_TITLES.ieSummits?.title, 'Tech Summits');
+    assert.equal(IRELAND_PANEL_TITLES.ieBusiness?.title, 'Business News');
+    assert.equal(IRELAND_PANEL_TITLES.ai?.title, 'AI/ML Updates');
+  });
+
+  it('should have short titles for mobile', () => {
+    // All Ireland panels should have short titles
+    for (const [panelId, config] of Object.entries(IRELAND_PANEL_TITLES)) {
+      assert.ok(config.shortTitle, `Missing shortTitle for ${panelId}`);
+      // Short title should be shorter or equal to full title
+      assert.ok(
+        (config.shortTitle?.length ?? 0) <= config.title.length,
+        `shortTitle should be shorter than title for ${panelId}`
+      );
+    }
+  });
+});
+
+// ==============================================================
+// Default Panel Titles Tests
+// ==============================================================
+
+describe('Default panel titles', () => {
+  it('should define common panels', () => {
+    const commonPanels = ['politics', 'tech', 'finance', 'ai', 'startups', 'security'];
+
+    commonPanels.forEach(panelId => {
+      assert.ok(DEFAULT_PANEL_TITLES[panelId], `Missing default panel title for ${panelId}`);
+    });
+  });
+
+  it('each default panel should have emoji and title', () => {
+    for (const [panelId, config] of Object.entries(DEFAULT_PANEL_TITLES)) {
+      assert.ok(config.emoji, `Missing emoji for ${panelId}`);
+      assert.ok(config.title, `Missing title for ${panelId}`);
+    }
+  });
+});
+
+// ==============================================================
+// getPanelTitleConfig Tests
+// ==============================================================
+
+describe('getPanelTitleConfig', () => {
+  it('should return Ireland config for Ireland panels', () => {
+    const config = getPanelTitleConfig('ieTech', 'ireland');
+    assert.ok(config);
+    assert.equal(config.emoji, '🇮🇪');
+    assert.equal(config.title, 'Irish Tech News');
+  });
+
+  it('should return Ireland config without explicit variant', () => {
+    // Ireland panels should be found even without variant specified
+    const config = getPanelTitleConfig('ieAcademic');
+    assert.ok(config);
+    assert.equal(config.emoji, '🎓');
+  });
+
+  it('should return default config for non-Ireland panels', () => {
+    const config = getPanelTitleConfig('politics');
+    assert.ok(config);
+    assert.equal(config.emoji, '🌍');
+    assert.equal(config.title, 'World News');
+  });
+
+  it('should return undefined for unknown panels', () => {
+    const config = getPanelTitleConfig('unknownPanel');
+    assert.equal(config, undefined);
+  });
+
+  it('should prefer Ireland config when variant is ireland', () => {
+    // 'ai' exists in both Ireland and default
+    const irelandConfig = getPanelTitleConfig('ai', 'ireland');
+    assert.ok(irelandConfig);
+    assert.equal(irelandConfig.emoji, '🤖');
+    assert.equal(irelandConfig.title, 'AI/ML Updates');
+  });
+});
+
+// ==============================================================
+// formatPanelTitle Tests
+// ==============================================================
+
+describe('formatPanelTitle', () => {
+  it('should format title with emoji', () => {
+    const title = formatPanelTitle('ieTech', undefined, false, 'ireland');
+    assert.equal(title, '🇮🇪 Irish Tech News');
+  });
+
+  it('should format title with count', () => {
+    const title = formatPanelTitle('ieTech', 15, false, 'ireland');
+    assert.equal(title, '🇮🇪 Irish Tech News (15)');
+  });
+
+  it('should use short title on mobile', () => {
+    const title = formatPanelTitle('ieTech', undefined, true, 'ireland');
+    assert.equal(title, '🇮🇪 Irish Tech');
+  });
+
+  it('should use short title with count on mobile', () => {
+    const title = formatPanelTitle('ieAcademic', 9, true, 'ireland');
+    assert.equal(title, '🎓 Academia (9)');
+  });
+
+  it('should fallback to capitalized panel ID for unknown panels', () => {
+    const title = formatPanelTitle('customPanel');
+    assert.equal(title, 'CustomPanel');
+  });
+
+  it('should fallback with count for unknown panels', () => {
+    const title = formatPanelTitle('customPanel', 5);
+    assert.equal(title, 'CustomPanel (5)');
+  });
+
+  it('should handle zero count', () => {
+    const title = formatPanelTitle('ieBusiness', 0, false, 'ireland');
+    assert.equal(title, '📊 Business News (0)');
+  });
+});
+
+// ==============================================================
+// Panel Title Consistency Tests
+// ==============================================================
+
+describe('Panel title consistency', () => {
+  it('Ireland and default should not have conflicting configs', () => {
+    // If a panel exists in both, they should have consistent emoji
+    for (const panelId of Object.keys(IRELAND_PANEL_TITLES)) {
+      const irelandConfig = IRELAND_PANEL_TITLES[panelId];
+      const defaultConfig = DEFAULT_PANEL_TITLES[panelId];
+      
+      if (irelandConfig && defaultConfig) {
+        // Both configs exist - emoji should match
+        assert.equal(
+          irelandConfig.emoji,
+          defaultConfig.emoji,
+          `Emoji mismatch for ${panelId}: Ireland=${irelandConfig.emoji}, Default=${defaultConfig.emoji}`
+        );
+      }
+    }
+  });
+
+  it('all emojis should be non-empty strings', () => {
+    const allConfigs = { ...DEFAULT_PANEL_TITLES, ...IRELAND_PANEL_TITLES };
+    
+    for (const [panelId, config] of Object.entries(allConfigs)) {
+      // Emoji should be non-empty (composed emoji can be up to 7+ code points)
+      assert.ok(
+        config.emoji.length >= 1,
+        `Empty emoji for ${panelId}`
+      );
+      // Emoji shouldn't be too long (probably misconfigured if > 10 chars)
+      assert.ok(
+        config.emoji.length <= 10,
+        `Suspiciously long emoji for ${panelId}: "${config.emoji}" (length: ${config.emoji.length})`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Optimize news panel titles by replacing uppercase titles with friendly emoji + title format.

## Changes
- **src/constants/panelTitles.ts**: Add panel title configurations with emoji, full title, and mobile short title
- **src/app/panel-layout.ts**: Use `getPanelTitleConfig` for friendly panel titles
- **src/styles/main.css**: Remove `text-transform: uppercase` from panel titles
- **tests/panel-titles.test.mts**: Add 21 unit tests

## Ireland Panel Titles

| Panel | Before | After |
|-------|--------|-------|
| ieTech | IRISH TECH | 🇮🇪 Irish Tech News |
| ieAcademic | ACADEMIA | 🎓 Academic Research |
| ieSemiconductors | SEMICONDUCTORS | 💎 Semiconductor Industry |
| ieDeals | TECH M&A | 🏢 Tech M&A |
| ieJobs | BIG TECH JOBS | 💼 Big Tech Jobs |
| startups | STARTUPS | 🚀 Startups & VC |
| ieSummits | SUMMITS | 🎤 Tech Summits |
| ieBusiness | BUSINESS | 📊 Business News |
| ai | AI/ML | 🤖 AI/ML Updates |

## Testing
- ✅ TypeScript typecheck passes
- ✅ 21 unit tests pass

Closes #133