### PR TITLE
feat(FR #137): Social Sharing Features

### DIFF
--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -9,6 +9,7 @@ import { getSourcePropagandaRisk, getSourceTier, getSourceType } from '@/config/
 import { SITE_VARIANT } from '@/config';
 import { t, getCurrentLanguage } from '@/services/i18n';
 import { classifyCluster, classifyNewsItem, NewsTier, shouldShowHotBadge, extractFundingAmount } from '@/utils/newsClassifier';
+import { createShareButton, initShareButton } from './ShareButton';
 
 type SortMode = 'relevance' | 'newest';
 
@@ -694,6 +695,11 @@ export class NewsPanel extends Panel {
           <span class="top-sources">${topSourcesHtml}</span>
           <span class="item-time">${formatTime(cluster.lastUpdated)}</span>
           ${getCurrentLanguage() !== 'en' ? `<button class="item-translate-btn" title="Translate" data-text="${escapeHtml(cluster.primaryTitle)}">文</button>` : ''}
+          ${createShareButton({
+            url: cluster.primaryLink,
+            title: cluster.primaryTitle,
+            type: 'news',
+          }, { size: 'small', position: 'top' })}
         </div>
         ${relatedAssetsHtml}
       </div>
@@ -745,8 +751,8 @@ export class NewsPanel extends Panel {
   }
 
   private bindRelatedAssetEvents(): void {
-    // Event delegation is set up in setupContentDelegation() — this is now a no-op
-    // kept for WindowedList callback compatibility
+    // Initialize share buttons after rendering
+    initShareButton(this.content);
   }
 
   private getLocalizedAssetLabel(type: RelatedAsset['type']): string {

--- a/src/components/ShareButton.ts
+++ b/src/components/ShareButton.ts
@@ -1,0 +1,310 @@
+/**
+ * ShareButton Component
+ *
+ * Reusable social sharing button with dropdown menu.
+ * Supports Twitter/X, LinkedIn, and copy-to-clipboard.
+ */
+
+import { escapeHtml } from '@/utils/sanitize';
+import { trackEvent } from '@/services/analytics';
+
+/**
+ * Share data configuration
+ */
+export interface ShareData {
+  /** URL to share */
+  url: string;
+  /** Title/headline */
+  title: string;
+  /** Optional description */
+  description?: string;
+  /** Type for analytics tracking */
+  type: 'news' | 'map' | 'brief';
+}
+
+/**
+ * Share button options
+ */
+export interface ShareButtonOptions {
+  /** Button size: 'small' | 'normal' */
+  size?: 'small' | 'normal';
+  /** Position for dropdown: 'top' | 'bottom' */
+  position?: 'top' | 'bottom';
+}
+
+/** Active share menu (for closing on outside click) */
+let activeMenu: HTMLElement | null = null;
+
+// Close menu when clicking outside (only in browser)
+if (typeof document !== 'undefined') {
+  document.addEventListener('click', (e) => {
+    if (activeMenu && !activeMenu.contains(e.target as Node)) {
+      activeMenu.classList.remove('open');
+      activeMenu = null;
+    }
+  });
+}
+
+/**
+ * Build URL with UTM parameters for tracking
+ */
+export function buildShareUrl(
+  baseUrl: string,
+  source: 'twitter' | 'linkedin' | 'copy'
+): string {
+  try {
+    // Use a fallback base for relative URLs in non-browser environments
+    const base = typeof window !== 'undefined' ? window.location.origin : 'https://ireland-monitor.app';
+    const url = new URL(baseUrl, base);
+    url.searchParams.set('utm_source', source);
+    url.searchParams.set('utm_medium', 'social');
+    url.searchParams.set('utm_campaign', 'share');
+    return url.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+/**
+ * Share to Twitter/X
+ */
+export function shareToTwitter(data: ShareData): void {
+  const url = buildShareUrl(data.url, 'twitter');
+  const text = `${data.title}`;
+  const hashtags = 'IrishTech';
+
+  const intentUrl = new URL('https://twitter.com/intent/tweet');
+  intentUrl.searchParams.set('text', text);
+  intentUrl.searchParams.set('url', url);
+  intentUrl.searchParams.set('hashtags', hashtags);
+
+  window.open(intentUrl.toString(), '_blank', 'width=550,height=420');
+
+  trackEvent('share', {
+    type: data.type,
+    platform: 'twitter',
+    title: data.title,
+  });
+}
+
+/**
+ * Share to LinkedIn
+ */
+export function shareToLinkedIn(data: ShareData): void {
+  const url = buildShareUrl(data.url, 'linkedin');
+
+  const shareUrl = new URL('https://www.linkedin.com/sharing/share-offsite/');
+  shareUrl.searchParams.set('url', url);
+
+  window.open(shareUrl.toString(), '_blank', 'width=550,height=420');
+
+  trackEvent('share', {
+    type: data.type,
+    platform: 'linkedin',
+    title: data.title,
+  });
+}
+
+/**
+ * Copy link to clipboard
+ */
+export async function copyShareLink(data: ShareData): Promise<boolean> {
+  const url = buildShareUrl(data.url, 'copy');
+
+  try {
+    await navigator.clipboard.writeText(url);
+    trackEvent('share', {
+      type: data.type,
+      platform: 'copy',
+      title: data.title,
+    });
+    return true;
+  } catch {
+    // Fallback for older browsers
+    const textarea = document.createElement('textarea');
+    textarea.value = url;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      trackEvent('share', {
+        type: data.type,
+        platform: 'copy',
+        title: data.title,
+      });
+      return true;
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}
+
+/**
+ * Show toast notification
+ */
+function showToast(message: string, type: 'success' | 'error' = 'success'): void {
+  // Check for existing toast container
+  let container = document.getElementById('share-toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'share-toast-container';
+    container.className = 'share-toast-container';
+    document.body.appendChild(container);
+  }
+
+  const toast = document.createElement('div');
+  toast.className = `share-toast share-toast-${type}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+
+  // Animate in
+  requestAnimationFrame(() => {
+    toast.classList.add('show');
+  });
+
+  // Remove after delay
+  setTimeout(() => {
+    toast.classList.remove('show');
+    setTimeout(() => toast.remove(), 200);
+  }, 2000);
+}
+
+/**
+ * Create share button HTML
+ */
+export function createShareButton(
+  data: ShareData,
+  options: ShareButtonOptions = {}
+): string {
+  const { size = 'small', position = 'top' } = options;
+
+  const buttonId = `share-btn-${Math.random().toString(36).slice(2, 9)}`;
+
+  return `
+    <div class="share-button share-button-${size}" id="${buttonId}" data-share='${escapeHtml(JSON.stringify(data))}'>
+      <button class="share-trigger" title="Share" aria-label="Share this content">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="18" cy="5" r="3"/>
+          <circle cx="6" cy="12" r="3"/>
+          <circle cx="18" cy="19" r="3"/>
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+        </svg>
+      </button>
+      <div class="share-menu share-menu-${position}">
+        <button class="share-option" data-action="twitter">
+          <span class="share-icon">𝕏</span>
+          <span>Twitter</span>
+        </button>
+        <button class="share-option" data-action="linkedin">
+          <span class="share-icon">in</span>
+          <span>LinkedIn</span>
+        </button>
+        <div class="share-divider"></div>
+        <button class="share-option" data-action="copy">
+          <span class="share-icon">📋</span>
+          <span>Copy link</span>
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Initialize share button event handlers
+ * Call this after adding share buttons to the DOM
+ */
+export function initShareButton(container: HTMLElement): void {
+  container.querySelectorAll<HTMLElement>('.share-button').forEach((btn) => {
+    // Skip if already initialized
+    if (btn.dataset.initialized === 'true') return;
+    btn.dataset.initialized = 'true';
+
+    const trigger = btn.querySelector<HTMLElement>('.share-trigger');
+    const menu = btn.querySelector<HTMLElement>('.share-menu');
+    if (!trigger || !menu) return;
+
+    // Parse share data
+    const dataStr = btn.dataset.share;
+    if (!dataStr) return;
+
+    let data: ShareData;
+    try {
+      data = JSON.parse(dataStr);
+    } catch {
+      return;
+    }
+
+    // Toggle menu
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      // Close other menus
+      if (activeMenu && activeMenu !== menu) {
+        activeMenu.classList.remove('open');
+      }
+
+      menu.classList.toggle('open');
+      activeMenu = menu.classList.contains('open') ? menu : null;
+    });
+
+    // Handle menu actions
+    menu.addEventListener('click', async (e) => {
+      const target = e.target as HTMLElement;
+      const option = target.closest<HTMLElement>('.share-option');
+      if (!option) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+
+      const action = option.dataset.action;
+
+      switch (action) {
+        case 'twitter':
+          shareToTwitter(data);
+          break;
+        case 'linkedin':
+          shareToLinkedIn(data);
+          break;
+        case 'copy': {
+          const success = await copyShareLink(data);
+          showToast(
+            success ? 'Link copied to clipboard!' : 'Failed to copy link',
+            success ? 'success' : 'error'
+          );
+          break;
+        }
+      }
+
+      // Close menu after action
+      menu.classList.remove('open');
+      activeMenu = null;
+    });
+  });
+}
+
+/**
+ * Create and mount a share button for the map toolbar
+ */
+export function createMapShareButton(): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'map-share-wrapper';
+
+  const data: ShareData = {
+    url: window.location.href,
+    title: 'Ireland Tech Map - Explore tech companies, data centers, and more',
+    type: 'map',
+  };
+
+  container.innerHTML = createShareButton(data, { size: 'normal', position: 'bottom' });
+
+  // Initialize events
+  setTimeout(() => initShareButton(container), 0);
+
+  return container;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -67,3 +67,4 @@ export * from './DailyBrief';
 export * from './AlertPanel';
 export * from './AlertSettings';
 export * from './BreakingNewsTickerPanel';
+export * from './ShareButton';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5,6 +5,7 @@
 @import './news-tiers.css';
 @import './skeleton.css';
 @import './cta-buttons.css';
+@import './share-button.css';
 
 /* IrishTech Daily - 爱尔兰绿色主题 */
 :root {

--- a/src/styles/share-button.css
+++ b/src/styles/share-button.css
@@ -1,0 +1,292 @@
+/**
+ * Share Button Styles
+ *
+ * Styling for social sharing buttons and dropdown menus.
+ */
+
+/* ============================================================
+   Share Button Container
+   ============================================================ */
+.share-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.share-button-small {
+  margin-left: auto;
+}
+
+.share-button-normal .share-trigger {
+  padding: 6px 10px;
+}
+
+/* ============================================================
+   Share Trigger Button
+   ============================================================ */
+.share-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 6px;
+  background: transparent;
+  border: 1px solid var(--border-subtle, #334155);
+  border-radius: 4px;
+  color: var(--text-dim, #94a3b8);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.share-trigger:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+  border-color: var(--text-dim, #64748b);
+  color: var(--text-primary, #e2e8f0);
+}
+
+.share-trigger:focus-visible {
+  outline: 2px solid var(--accent, #3B82F6);
+  outline-offset: 2px;
+}
+
+.share-trigger svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ============================================================
+   Share Menu Dropdown
+   ============================================================ */
+.share-menu {
+  position: absolute;
+  right: 0;
+  min-width: 140px;
+  padding: 4px;
+  background: var(--bg-primary, #0f172a);
+  border: 1px solid var(--border-subtle, #334155);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+  z-index: 1000;
+}
+
+.share-menu-top {
+  bottom: 100%;
+  margin-bottom: 6px;
+  transform: translateY(-8px);
+}
+
+.share-menu-bottom {
+  top: 100%;
+  margin-top: 6px;
+  transform: translateY(8px);
+}
+
+.share-menu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+/* ============================================================
+   Share Options
+   ============================================================ */
+.share-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-primary, #e2e8f0);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.share-option:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+}
+
+.share-option:focus-visible {
+  outline: 2px solid var(--accent, #3B82F6);
+  outline-offset: -2px;
+}
+
+.share-icon {
+  width: 18px;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+/* Platform-specific icon colors */
+.share-option[data-action="twitter"] .share-icon {
+  color: #fff;
+}
+
+.share-option[data-action="linkedin"] .share-icon {
+  color: #0A66C2;
+  background: #fff;
+  border-radius: 2px;
+  font-size: 11px;
+  padding: 1px 2px;
+}
+
+/* ============================================================
+   Share Divider
+   ============================================================ */
+.share-divider {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border-subtle, #334155);
+}
+
+/* ============================================================
+   Toast Notifications
+   ============================================================ */
+.share-toast-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.share-toast {
+  padding: 10px 20px;
+  background: var(--bg-primary, #1e293b);
+  border: 1px solid var(--border-subtle, #334155);
+  border-radius: 8px;
+  color: var(--text-primary, #e2e8f0);
+  font-size: 13px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.share-toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.share-toast-success {
+  border-color: #22c55e;
+}
+
+.share-toast-error {
+  border-color: #ef4444;
+}
+
+/* ============================================================
+   Map Share Wrapper
+   ============================================================ */
+.map-share-wrapper {
+  display: inline-flex;
+}
+
+.map-share-wrapper .share-trigger {
+  background: var(--bg-primary, #1e293b);
+  padding: 6px 10px;
+}
+
+/* ============================================================
+   News Card Integration
+   ============================================================ */
+.item .share-button {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.item:hover .share-button {
+  opacity: 1;
+}
+
+/* Always show on touch devices */
+@media (hover: none) {
+  .item .share-button {
+    opacity: 1;
+  }
+}
+
+/* ============================================================
+   Responsive Adjustments
+   ============================================================ */
+@media (max-width: 768px) {
+  .share-menu {
+    min-width: 130px;
+  }
+
+  .share-option {
+    padding: 10px 12px;
+  }
+
+  .share-toast-container {
+    bottom: 80px;
+    left: 16px;
+    right: 16px;
+    transform: none;
+  }
+
+  .share-toast {
+    text-align: center;
+  }
+}
+
+/* ============================================================
+   Light Theme
+   ============================================================ */
+[data-theme="light"] .share-trigger {
+  border-color: #e2e8f0;
+  color: #64748b;
+}
+
+[data-theme="light"] .share-trigger:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+  color: #334155;
+}
+
+[data-theme="light"] .share-menu {
+  background: #fff;
+  border-color: #e2e8f0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .share-option {
+  color: #334155;
+}
+
+[data-theme="light"] .share-option:hover {
+  background: #f8fafc;
+}
+
+[data-theme="light"] .share-divider {
+  background: #e2e8f0;
+}
+
+[data-theme="light"] .share-toast {
+  background: #fff;
+  border-color: #e2e8f0;
+  color: #334155;
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .share-menu,
+  .share-toast {
+    transition: none;
+  }
+}

--- a/tests/share-button.test.mts
+++ b/tests/share-button.test.mts
@@ -1,0 +1,159 @@
+/**
+ * Share Button Tests
+ *
+ * Tests for social sharing functionality.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Import functions to test
+import {
+  buildShareUrl,
+  type ShareData,
+} from '../src/components/ShareButton';
+
+// ==============================================================
+// URL Building Tests
+// ==============================================================
+
+describe('buildShareUrl', () => {
+  it('should add UTM parameters for twitter', () => {
+    const url = buildShareUrl('https://example.com/news/123', 'twitter');
+    assert.ok(url.includes('utm_source=twitter'));
+    assert.ok(url.includes('utm_medium=social'));
+    assert.ok(url.includes('utm_campaign=share'));
+  });
+
+  it('should add UTM parameters for linkedin', () => {
+    const url = buildShareUrl('https://example.com/news/456', 'linkedin');
+    assert.ok(url.includes('utm_source=linkedin'));
+    assert.ok(url.includes('utm_medium=social'));
+  });
+
+  it('should add UTM parameters for copy', () => {
+    const url = buildShareUrl('https://example.com/map', 'copy');
+    assert.ok(url.includes('utm_source=copy'));
+  });
+
+  it('should preserve existing query parameters', () => {
+    const url = buildShareUrl('https://example.com/map?zoom=10', 'twitter');
+    assert.ok(url.includes('zoom=10'));
+    assert.ok(url.includes('utm_source=twitter'));
+  });
+
+  it('should handle relative URLs', () => {
+    const url = buildShareUrl('/news/789', 'linkedin');
+    assert.ok(url.includes('utm_source=linkedin'));
+  });
+
+  it('should handle invalid URLs gracefully', () => {
+    const url = buildShareUrl('not-a-valid-url', 'copy');
+    // Should return the original URL if parsing fails
+    assert.equal(typeof url, 'string');
+  });
+});
+
+// ==============================================================
+// ShareData Type Tests
+// ==============================================================
+
+describe('ShareData interface', () => {
+  it('should accept valid news share data', () => {
+    const data: ShareData = {
+      url: 'https://example.com/news/1',
+      title: 'Test News Title',
+      type: 'news',
+    };
+    assert.ok(data.url);
+    assert.ok(data.title);
+    assert.equal(data.type, 'news');
+  });
+
+  it('should accept valid map share data', () => {
+    const data: ShareData = {
+      url: 'https://example.com/map?lat=53.35',
+      title: 'Ireland Tech Map',
+      description: 'Explore tech companies',
+      type: 'map',
+    };
+    assert.ok(data.description);
+    assert.equal(data.type, 'map');
+  });
+
+  it('should accept valid brief share data', () => {
+    const data: ShareData = {
+      url: 'https://example.com/brief/2026-03-25',
+      title: "Today's AI Brief",
+      type: 'brief',
+    };
+    assert.equal(data.type, 'brief');
+  });
+});
+
+// ==============================================================
+// Edge Cases
+// ==============================================================
+
+describe('Edge Cases', () => {
+  it('should handle empty URL', () => {
+    const url = buildShareUrl('', 'twitter');
+    assert.equal(typeof url, 'string');
+  });
+
+  it('should handle URL with special characters', () => {
+    const url = buildShareUrl('https://example.com/news?q=test&lang=中文', 'linkedin');
+    assert.ok(url.includes('utm_source=linkedin'));
+  });
+
+  it('should handle URL with hash', () => {
+    const url = buildShareUrl('https://example.com/map#dublin', 'copy');
+    assert.ok(url.includes('utm_source=copy'));
+  });
+
+  it('should encode UTM values properly', () => {
+    const url = buildShareUrl('https://example.com/', 'twitter');
+    // URL should be properly encoded
+    assert.ok(!url.includes(' '));
+  });
+});
+
+// ==============================================================
+// Integration Tests
+// ==============================================================
+
+describe('Integration', () => {
+  it('should generate valid Twitter intent URL format', () => {
+    const shareUrl = buildShareUrl('https://ireland-monitor.app/news/123', 'twitter');
+    // The final Twitter URL should include our UTM-tagged URL
+    assert.ok(shareUrl.includes('ireland-monitor.app'));
+    assert.ok(shareUrl.includes('utm_source=twitter'));
+  });
+
+  it('should generate valid LinkedIn share URL format', () => {
+    const shareUrl = buildShareUrl('https://ireland-monitor.app/news/456', 'linkedin');
+    assert.ok(shareUrl.includes('ireland-monitor.app'));
+    assert.ok(shareUrl.includes('utm_source=linkedin'));
+  });
+
+  it('should handle full news workflow', () => {
+    // Simulate the full flow of sharing a news item
+    const newsUrl = 'https://ireland-monitor.app/news/intel-12b-investment';
+    const title = 'Intel to invest €12B in Ireland';
+
+    // Build share URLs for each platform
+    const twitterUrl = buildShareUrl(newsUrl, 'twitter');
+    const linkedinUrl = buildShareUrl(newsUrl, 'linkedin');
+    const copyUrl = buildShareUrl(newsUrl, 'copy');
+
+    // All should contain the original URL
+    assert.ok(twitterUrl.includes('intel-12b-investment'));
+    assert.ok(linkedinUrl.includes('intel-12b-investment'));
+    assert.ok(copyUrl.includes('intel-12b-investment'));
+
+    // Each should have its own UTM source
+    assert.ok(twitterUrl.includes('utm_source=twitter'));
+    assert.ok(linkedinUrl.includes('utm_source=linkedin'));
+    assert.ok(copyUrl.includes('utm_source=copy'));
+  });
+});


### PR DESCRIPTION
## Summary
Add social sharing functionality to news cards with Twitter/X, LinkedIn, and copy-to-clipboard options.

## Changes

### Share Button Component
- **src/components/ShareButton.ts**: Reusable share button
  - `shareToTwitter()`: Twitter intent with title + hashtags
  - `shareToLinkedIn()`: LinkedIn share-offsite
  - `copyShareLink()`: Clipboard API with fallback
  - `buildShareUrl()`: UTM parameter tracking

### Styling
- **src/styles/share-button.css**: Button and menu styling
  - Dropdown menu with slide animation
  - Toast notifications (success/error)
  - Light/dark theme support
  - Mobile-responsive

### Integration
- **src/components/NewsPanel.ts**: Add share button to news cards
- Shows on hover (desktop) / always visible (touch devices)

## UTM Tracking

All shared links include:
- `utm_source`: twitter | linkedin | copy
- `utm_medium`: social
- `utm_campaign`: share

## Testing
- ✅ TypeScript typecheck passes
- ✅ 16 unit tests pass

Closes #137