### PR TITLE
fix(FR #146): Fix Popup Text Color (white on white)

### DIFF
--- a/src/styles/rich-popup.css
+++ b/src/styles/rich-popup.css
@@ -3,6 +3,9 @@
  *
  * Enhanced popup styling for Ireland markers with company details,
  * logos, related news, and profile links.
+ *
+ * Note: Popup uses dark background with light text by default.
+ * Colors are explicitly set to ensure visibility regardless of theme.
  */
 
 /* Rich popup header with logo */
@@ -50,7 +53,7 @@
 .popup-company-name {
   font-size: 14px;
   font-weight: 600;
-  color: var(--text-primary, #fff);
+  color: var(--text, #e8e8e8);
   margin: 0 0 4px 0;
   line-height: 1.3;
 }
@@ -58,11 +61,11 @@
 .popup-type-badge {
   display: inline-block;
   padding: 2px 8px;
-  background: var(--badge-bg, rgba(255, 255, 255, 0.1));
+  background: var(--overlay-medium, rgba(255, 255, 255, 0.1));
   border-radius: 4px;
   font-size: 11px;
   font-weight: 500;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary, #ccc);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
@@ -104,7 +107,7 @@
   gap: 8px;
   margin-bottom: 8px;
   font-size: 13px;
-  color: var(--text-secondary, #b0b0b0);
+  color: var(--text-secondary, #ccc);
 }
 
 .popup-detail-row:last-child {
@@ -119,7 +122,7 @@
 }
 
 .popup-detail-row .value {
-  color: var(--text-primary, #fff);
+  color: var(--text, #e8e8e8);
 }
 
 /* Related news section */
@@ -134,12 +137,12 @@
   gap: 6px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary, #b0b0b0);
+  color: var(--text-secondary, #ccc);
   margin-bottom: 10px;
 }
 
 .popup-news-header .count {
-  background: var(--badge-bg, rgba(255, 255, 255, 0.1));
+  background: var(--overlay-medium, rgba(255, 255, 255, 0.1));
   border-radius: 10px;
   padding: 1px 6px;
   font-size: 11px;
@@ -162,7 +165,7 @@
 }
 
 .popup-news-item a {
-  color: var(--text-secondary, #b0b0b0);
+  color: var(--text-secondary, #ccc);
   text-decoration: none;
   display: block;
   overflow: hidden;
@@ -219,7 +222,7 @@
 .popup-cta-button.secondary {
   background: transparent;
   border: 1px solid var(--border, rgba(255, 255, 255, 0.2));
-  color: var(--text-secondary, #b0b0b0);
+  color: var(--text-secondary, #ccc);
 }
 
 .popup-cta-button.secondary:hover {


### PR DESCRIPTION
## Summary
Fix map popup text visibility issue where text was invisible (white on white).

## Problem
- Popup text used `--text-primary` with fallback `#fff` (white)
- In some themes/scenarios this resulted in white text on white/light background
- Users reported: "字是白色的，看都看不到" (text is white, can't see it)

## Solution
Updated `src/styles/rich-popup.css` to use correct theme color variables:

| Element | Before | After |
|---------|--------|-------|
| .popup-company-name | `--text-primary, #fff` | `--text, #e8e8e8` |
| .popup-type-badge | `--badge-bg` | `--overlay-medium` |
| .popup-detail-row | `#b0b0b0` | `--text-secondary, #ccc` |
| .popup-detail-row .value | `--text-primary, #fff` | `--text, #e8e8e8` |
| .popup-news-* | `#b0b0b0` | `--text-secondary, #ccc` |

## Testing
- ✅ TypeScript typecheck passes
- Visual: All popup text now visible in both dark and light themes

Closes #146