### PR TITLE
fix(FR #152): Fix Company Not Found for Unicorns

### DIFF
--- a/src/components/CompanyProfile.ts
+++ b/src/components/CompanyProfile.ts
@@ -7,7 +7,10 @@
 
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import { IRELAND_COMPANIES } from '@/data/ireland-companies';
-import type { Company } from '@/types/company';
+import { IRISH_UNICORNS, type IrishUnicorn } from '@/config/variants/ireland/data/unicorns';
+import { IRELAND_TECH_HQS, type IrelandTechHQ } from '@/config/variants/ireland/data/tech-hqs';
+import { IRELAND_DATA_CENTERS, type IrelandDataCenter } from '@/config/variants/ireland/data/data-centers';
+import type { Company, CompanyIndustry, EmployeeRange, CompanyTag } from '@/types/company';
 import { renderLogo } from '@/utils/logoFallback';
 
 /**
@@ -106,12 +109,143 @@ export class CompanyProfile {
 
   /**
    * Find company by ID or slug
+   * Searches across multiple data sources:
+   * 1. IRELAND_COMPANIES (detailed company profiles)
+   * 2. IRISH_UNICORNS (unicorn/high-growth companies)
+   * 3. IRELAND_TECH_HQS (multinational tech HQs)
+   * 4. IRELAND_DATA_CENTERS (data center facilities)
    */
   private findCompany(id: string): Company | undefined {
     const lowerId = id.toLowerCase();
-    return IRELAND_COMPANIES.find(
+
+    // 1. Check main company database first
+    const company = IRELAND_COMPANIES.find(
       c => c.id.toLowerCase() === lowerId || c.slug.toLowerCase() === lowerId
     );
+    if (company) return company;
+
+    // 2. Check Irish Unicorns and convert to Company type
+    const unicorn = IRISH_UNICORNS.find(u => u.id.toLowerCase() === lowerId);
+    if (unicorn) return this.convertUnicornToCompany(unicorn);
+
+    // 3. Check Tech HQs and convert to Company type
+    const techHQ = IRELAND_TECH_HQS.find(h => h.id.toLowerCase() === lowerId);
+    if (techHQ) return this.convertTechHQToCompany(techHQ);
+
+    // 4. Check Data Centers and convert to Company type
+    const dataCenter = IRELAND_DATA_CENTERS.find(d => d.id.toLowerCase() === lowerId);
+    if (dataCenter) return this.convertDataCenterToCompany(dataCenter);
+
+    return undefined;
+  }
+
+  /**
+   * Convert IrishUnicorn to Company type
+   */
+  private convertUnicornToCompany(unicorn: IrishUnicorn): Company {
+    // Map employee count to EmployeeRange
+    const employeeRange = unicorn.employees
+      ? this.mapEmployeeCount(unicorn.employees)
+      : undefined;
+
+    // Map category to tags
+    const tags: CompanyTag[] = [];
+    if (unicorn.category === 'unicorn') tags.push('unicorn');
+    tags.push('irish-founded');
+
+    return {
+      id: unicorn.id,
+      slug: unicorn.id,
+      name: unicorn.name,
+      description: unicorn.description,
+      founded: unicorn.founded,
+      headquarters: `${unicorn.location}, Ireland`,
+      industry: this.mapSectorToIndustry(unicorn.sector),
+      employeeCount: employeeRange,
+      website: unicorn.website,
+      tags,
+      coordinates: [unicorn.lng, unicorn.lat],
+      funding: unicorn.valuation ? { total: unicorn.valuation } : undefined,
+    };
+  }
+
+  /**
+   * Convert IrelandTechHQ to Company type
+   */
+  private convertTechHQToCompany(hq: IrelandTechHQ): Company {
+    const employeeRange = hq.employees
+      ? this.mapEmployeeCount(hq.employees)
+      : undefined;
+
+    return {
+      id: hq.id,
+      slug: hq.id,
+      name: hq.company,
+      description: hq.description,
+      founded: hq.founded,
+      headquarters: `${hq.location}, Ireland`,
+      industry: 'Enterprise',
+      employeeCount: employeeRange,
+      website: hq.website,
+      tags: ['tech-hq', 'multinational'],
+      coordinates: [hq.lng, hq.lat],
+      address: hq.address,
+    };
+  }
+
+  /**
+   * Convert IrelandDataCenter to Company type
+   */
+  private convertDataCenterToCompany(dc: IrelandDataCenter): Company {
+    return {
+      id: dc.id,
+      slug: dc.id,
+      name: dc.name,
+      description: dc.description,
+      headquarters: `${dc.location}, Ireland`,
+      industry: 'Data Center',
+      website: dc.website,
+      tags: ['data-center'],
+      coordinates: [dc.lng, dc.lat],
+    };
+  }
+
+  /**
+   * Map employee count number to EmployeeRange
+   */
+  private mapEmployeeCount(count: number): EmployeeRange {
+    if (count <= 10) return '1-10';
+    if (count <= 50) return '11-50';
+    if (count <= 200) return '51-200';
+    if (count <= 500) return '201-500';
+    if (count <= 1000) return '501-1000';
+    if (count <= 5000) return '1001-5000';
+    if (count <= 10000) return '5001-10000';
+    return '10000+';
+  }
+
+  /**
+   * Map sector string to CompanyIndustry type
+   */
+  private mapSectorToIndustry(sector: string): CompanyIndustry {
+    const sectorMap: Record<string, CompanyIndustry> = {
+      'SaaS': 'SaaS',
+      'Fintech': 'Fintech',
+      'FinTech': 'Fintech',
+      'FoodTech': 'E-commerce',
+      'Healthcare': 'Healthcare',
+      'Gaming': 'Gaming',
+      'Semiconductor': 'Semiconductor',
+      'Data Center': 'Data Center',
+      'Cybersecurity': 'Cybersecurity',
+      'Cloud': 'Cloud',
+      'Enterprise': 'Enterprise',
+      'Consumer': 'Consumer',
+      'AI': 'AI/ML',
+      'AI/ML': 'AI/ML',
+      'Tech': 'Other',
+    };
+    return sectorMap[sector] || 'Other';
   }
 
   /**

--- a/tests/company-profile.test.mts
+++ b/tests/company-profile.test.mts
@@ -38,14 +38,60 @@ const mockCompanies = [
   },
 ];
 
+// Mock unicorn data for testing
+const mockUnicorns = [
+  {
+    id: 'flipdish',
+    name: 'Flipdish',
+    location: 'Dublin',
+    lat: 53.3423,
+    lng: -6.2412,
+    category: 'unicorn',
+    sector: 'FoodTech',
+    founded: 2015,
+    employees: 500,
+    valuation: '$1.2B',
+  },
+  {
+    id: 'fenergo',
+    name: 'Fenergo',
+    location: 'Dublin',
+    lat: 53.3445,
+    lng: -6.2378,
+    category: 'high-growth',
+    sector: 'FinTech',
+    founded: 2009,
+    employees: 1000,
+  },
+];
+
 /**
  * Find company by ID or slug (matching the component logic)
+ * Also searches unicorn data
  */
 function findCompany(id: string) {
   const lowerId = id.toLowerCase();
-  return mockCompanies.find(
+
+  // Check main companies first
+  const company = mockCompanies.find(
     c => c.id.toLowerCase() === lowerId || c.slug.toLowerCase() === lowerId
   );
+  if (company) return company;
+
+  // Check unicorns
+  const unicorn = mockUnicorns.find(u => u.id.toLowerCase() === lowerId);
+  if (unicorn) {
+    return {
+      id: unicorn.id,
+      slug: unicorn.id,
+      name: unicorn.name,
+      headquarters: `${unicorn.location}, Ireland`,
+      industry: unicorn.sector,
+      founded: unicorn.founded,
+    };
+  }
+
+  return undefined;
 }
 
 /**
@@ -213,5 +259,51 @@ describe('Integration', () => {
     assert.ok(companyId);
     const company = findCompany(companyId);
     assert.equal(company, undefined);
+  });
+});
+
+// ==============================================================
+// Unicorn Lookup Tests (FR #152)
+// ==============================================================
+
+describe('Unicorn Lookup', () => {
+  it('should find unicorn by ID', () => {
+    const company = findCompany('flipdish');
+    assert.ok(company);
+    assert.equal(company.name, 'Flipdish');
+  });
+
+  it('should convert unicorn to company format', () => {
+    const company = findCompany('flipdish');
+    assert.ok(company);
+    assert.equal(company.id, 'flipdish');
+    assert.equal(company.slug, 'flipdish');
+    assert.equal(company.headquarters, 'Dublin, Ireland');
+    assert.equal(company.industry, 'FoodTech');
+  });
+
+  it('should find unicorn case-insensitively', () => {
+    const company1 = findCompany('FLIPDISH');
+    const company2 = findCompany('Flipdish');
+    const company3 = findCompany('flipdish');
+    assert.ok(company1);
+    assert.ok(company2);
+    assert.ok(company3);
+    assert.equal(company1.id, company2.id);
+  });
+
+  it('should find high-growth company', () => {
+    const company = findCompany('fenergo');
+    assert.ok(company);
+    assert.equal(company.name, 'Fenergo');
+    assert.equal(company.industry, 'FinTech');
+  });
+
+  it('should prefer main company over unicorn', () => {
+    // intercom exists in both mockCompanies and could exist in unicorns
+    const company = findCompany('intercom');
+    assert.ok(company);
+    // Should get the one from mockCompanies which has description
+    assert.equal(company.description, 'Customer messaging platform');
   });
 });


### PR DESCRIPTION
## Summary
Fix "Company Not Found" error when clicking View Company Profile on Irish Unicorn markers (e.g., Flipdish).

## Problem
- Click on Irish Unicorn marker (e.g., Flipdish)
- Click "View Company Profile →" button
- Shows "Company Not Found" error
- User feedback: "view company profile点进去啥也没"

## Root Cause
`CompanyProfile.findCompany()` only searched `IRELAND_COMPANIES` data, but Unicorn IDs like "flipdish" exist in `IRISH_UNICORNS` data.

## Solution
Extend `findCompany()` to search across multiple data sources:

1. **IRELAND_COMPANIES** - Main company profiles (detailed data)
2. **IRISH_UNICORNS** - Unicorn/high-growth companies (Flipdish, Fenergo, etc.)
3. **IRELAND_TECH_HQS** - Multinational tech HQs (Google EMEA, Meta, etc.)
4. **IRELAND_DATA_CENTERS** - Data center facilities

When found in alternative sources, data is converted to `Company` type with field mapping.

## Changes
- `src/components/CompanyProfile.ts`:
  - Extended `findCompany()` with multi-source lookup
  - Added `convertUnicornToCompany()`
  - Added `convertTechHQToCompany()`
  - Added `convertDataCenterToCompany()`
  - Added helper methods for field mapping

## Testing
- ✅ TypeScript typecheck passes
- ✅ 23 unit tests pass (5 new for unicorn lookup)

Closes #152