### PR TITLE
fix(FR #156): Preserve Map View When Opening Country Intelligence

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -174,7 +174,8 @@ export class CountryIntelManager implements AppModule {
 
     this.ctx.countryBriefPage.show(country, code, score, signals);
     this.ctx.map?.highlightCountry(code);
-    this.ctx.map?.fitCountry(code);
+    // Note: Removed fitCountry() to preserve user's current map view (FR #156)
+    // Users found auto-zoom disruptive when exploring specific regions
 
     if (opts?.maximize) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
Fix the annoying auto-zoom behavior when clicking on the map to open Country Intelligence panel.

## Problem
When viewing a specific area (e.g., Dublin at zoom level 11) and clicking on the map:
- Intelligence panel opens ✅
- **Map auto-zooms to full country view** ❌
- User has to re-zoom and re-navigate back to where they were

User feedback:
> "每次点击爱尔兰地图，都会出现爱尔兰右侧窗口，然后地图缩小的全局这个很烦"

## Solution
Remove the `fitCountry()` call in `openCountryBriefByCode()`.

**Before:**
```javascript
this.ctx.map?.highlightCountry(code);
this.ctx.map?.fitCountry(code);  // Auto-zooms to country bounds
```

**After:**
```javascript
this.ctx.map?.highlightCountry(code);  // Keep border highlight
// fitCountry() removed - preserve user's view
```

## Testing
- ✅ TypeScript typecheck passes
- Manual testing recommended:
  - Zoom to Dublin (level 11)
  - Click on map
  - Verify: Panel opens, map stays at Dublin view

Closes #156