### PR TITLE
fix(FR #162): Add AI Companies and Universities to LAYERS Panel

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -120,8 +120,9 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'natural', 'weather', 'outages', 'dayNight',
   ],
   ireland: [
-    'semiconductorHubs', 'irelandDataCenters', 'irelandTechHQs', 'irishUnicorns', 'startupHubs',
-    'cloudRegions', 'accelerators', 'techEvents',
+    'semiconductorHubs', 'irelandDataCenters', 'irelandTechHQs', 'irishUnicorns',
+    'irelandAICompanies', 'irelandUniversities',
+    'startupHubs', 'cloudRegions', 'accelerators', 'techEvents',
   ],
 };
 


### PR DESCRIPTION
## Summary
Add AI Companies and Universities toggles to the LAYERS panel for Ireland variant.

## Problem
- AI Companies (FR #158) and Universities (FR #159) layers were implemented
- LEGEND showed these layers correctly
- But LAYERS panel was missing the toggle checkboxes
- Users couldn't toggle these layers on/off

## Root Cause
`VARIANT_LAYER_ORDER.ireland` in `map-layer-definitions.ts` didn't include:
- `irelandAICompanies`
- `irelandUniversities`

## Solution
Added both layer keys to the Ireland variant's layer order array.

```typescript
// Before
ireland: [
  'semiconductorHubs', 'irelandDataCenters', 'irelandTechHQs', 'irishUnicorns', 'startupHubs',
  'cloudRegions', 'accelerators', 'techEvents',
],

// After
ireland: [
  'semiconductorHubs', 'irelandDataCenters', 'irelandTechHQs', 'irishUnicorns',
  'irelandAICompanies', 'irelandUniversities',
  'startupHubs', 'cloudRegions', 'accelerators', 'techEvents',
],
```

## Testing
- ✅ TypeScript typecheck passes
- LAYERS panel now shows 10 layers for Ireland variant

Closes #162