### PR TITLE
feat(FR #168): Add 7 University News Feeds to Academic Panel

### DIFF
--- a/src/config/variants/ireland.ts
+++ b/src/config/variants/ireland.ts
@@ -39,7 +39,9 @@ export const FEEDS: Record<string, Feed[]> = {
   ],
 
   // 爱尔兰学术机构（通过 Google News）
+  // 爱尔兰学术机构新闻（9所大学 + 研究机构）
   ieAcademic: [
+    // Dublin Universities
     { 
       name: 'TCD News', 
       url: rss('https://news.google.com/rss/search?q=site:tcd.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
@@ -48,6 +50,38 @@ export const FEEDS: Record<string, Feed[]> = {
       name: 'UCD News', 
       url: rss('https://news.google.com/rss/search?q=site:ucd.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
     },
+    { 
+      name: 'DCU News', 
+      url: rss('https://news.google.com/rss/search?q=site:dcu.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+    { 
+      name: 'TU Dublin News', 
+      url: rss('https://news.google.com/rss/search?q=site:tudublin.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+    { 
+      name: 'RCSI News', 
+      url: rss('https://news.google.com/rss/search?q=site:rcsi.com+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+
+    // Regional Universities
+    { 
+      name: 'Maynooth University News', 
+      url: rss('https://news.google.com/rss/search?q=site:maynoothuniversity.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+    { 
+      name: 'UCC News', 
+      url: rss('https://news.google.com/rss/search?q=site:ucc.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+    { 
+      name: 'University of Galway News', 
+      url: rss('https://news.google.com/rss/search?q=site:universityofgalway.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+    { 
+      name: 'UL News', 
+      url: rss('https://news.google.com/rss/search?q=site:ul.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 
+    },
+
+    // Research Institutions
     { 
       name: 'SFI Announcements', 
       url: rss('https://news.google.com/rss/search?q=site:sfi.ie+when:7d&hl=en-IE&gl=IE&ceid=IE:en') 


### PR DESCRIPTION
## Summary
Expand the Academic Research panel (ieAcademic) to cover all 9 universities shown on the 🎓 Universities map layer.

## Changes

### Before
4 feeds: TCD, UCD, SFI, Enterprise Ireland

### After
11 feeds organized by location:

| Category | Universities |
|----------|-------------|
| **Dublin (5)** | TCD, UCD, DCU, TU Dublin, RCSI |
| **Regional (4)** | Maynooth, UCC, Galway, UL |
| **Research (2)** | SFI, Enterprise Ireland |

### New University Feeds Added

| University | Feed URL Pattern |
|------------|-----------------|
| DCU | `site:dcu.ie` |
| TU Dublin | `site:tudublin.ie` |
| RCSI | `site:rcsi.com` |
| Maynooth | `site:maynoothuniversity.ie` |
| UCC | `site:ucc.ie` |
| Galway | `site:universityofgalway.ie` |
| UL | `site:ul.ie` |

All feeds use Google News RSS with `when:7d` for recent news.

## File Changes
- `src/config/variants/ireland.ts`: Expand `ieAcademic` from 4 to 11 feeds

## Testing
- ✅ TypeScript typecheck passes
- Config-only change, uses existing RSS infrastructure

Closes #168