### PR TITLE
fix(FR #170): Remove Cloud Regions Layer from Ireland Variant

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -122,7 +122,7 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
   ireland: [
     'semiconductorHubs', 'irelandDataCenters', 'irelandTechHQs', 'irishUnicorns',
     'irelandAICompanies', 'irelandUniversities',
-    'startupHubs', 'cloudRegions', 'accelerators', 'techEvents',
+    'startupHubs', 'accelerators', 'techEvents',
   ],
 };
 

--- a/src/config/variants/ireland.ts
+++ b/src/config/variants/ireland.ts
@@ -248,7 +248,7 @@ const IRELAND_MAP_LAYERS: MapLayers = {
   displacement: false,
   climate: false,
   startupHubs: true,  // 科技创业中心
-  cloudRegions: true, // 云区域
+  cloudRegions: false, // 禁用 - 与 Data Centers 重复，用户更关心物理位置 (FR #170)
   accelerators: true, // 加速器
   techHQs: true,      // 科技公司总部
   techEvents: true,   // 科技活动


### PR DESCRIPTION
## Summary
Remove the Cloud Regions layer from the Ireland variant to eliminate visual overlap with Data Centers layer.

## Problem
- Cloud Regions layer shows large circles representing cloud service coverage areas
- Data Centers layer shows precise physical location markers
- Both layers mark the same locations, causing visual redundancy
- Users prefer knowing the exact physical location of data centers

## Solution
Remove `cloudRegions` from the Ireland variant:

### Changes
1. **`src/config/map-layer-definitions.ts`**
   - Remove `'cloudRegions'` from `VARIANT_LAYER_ORDER.ireland` array

2. **`src/config/variants/ireland.ts`**
   - Set `cloudRegions: false` in `IRELAND_MAP_LAYERS`

### Before
LAYERS panel showed 10 items including:
- ☁ Cloud Regions (large circles)
- 🏢 Data Centers (Ireland) (precise markers)

### After
LAYERS panel shows 9 items:
- 🏢 Data Centers (Ireland) only (precise markers with physical addresses)

## User Benefit
- Cleaner map visualization without overlapping markers
- Data Centers popups include cloud region info when relevant
- Precise physical locations instead of abstract coverage areas

## Testing
- ✅ TypeScript typecheck passes
- Config-only change

Closes #170