### PR TITLE
fix(FR #183): force English UI, disable browser language detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "fast-xml-parser": "^5.3.7",
         "globe.gl": "^2.45.0",
         "i18next": "^25.8.10",
-        "i18next-browser-languagedetector": "^8.2.1",
         "maplibre-gl": "^5.16.0",
         "marked": "^17.0.3",
         "onnxruntime-web": "^1.23.2",
@@ -10645,15 +10644,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/i18next-browser-languagedetector": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
-      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "fast-xml-parser": "^5.3.7",
     "globe.gl": "^2.45.0",
     "i18next": "^25.8.10",
-    "i18next-browser-languagedetector": "^8.2.1",
     "maplibre-gl": "^5.16.0",
     "marked": "^17.0.3",
     "onnxruntime-web": "^1.23.2",

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -1,103 +1,43 @@
 import i18next from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 
-// English is always needed as fallback — bundle it eagerly.
+// English is always needed — bundle it eagerly.
 import enTranslation from '../locales/en.json';
 
-const SUPPORTED_LANGUAGES = ['en', 'bg', 'cs', 'fr', 'de', 'el', 'es', 'it', 'pl', 'pt', 'nl', 'sv', 'ru', 'ar', 'zh', 'ja', 'ko', 'ro', 'tr', 'th', 'vi'] as const;
-type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
+/**
+ * FR #183: Force English UI regardless of browser language.
+ * Removed LanguageDetector to disable automatic language detection.
+ */
+const FORCED_LANGUAGE = 'en';
+
 type TranslationDictionary = Record<string, unknown>;
 
-const SUPPORTED_LANGUAGE_SET = new Set<SupportedLanguage>(SUPPORTED_LANGUAGES);
-const loadedLanguages = new Set<SupportedLanguage>();
-
-// Lazy-load only the locale that's actually needed — all others stay out of the bundle.
-const localeModules = import.meta.glob<TranslationDictionary>(
-  ['../locales/*.json', '!../locales/en.json'],
-  { import: 'default' },
-);
-
-const RTL_LANGUAGES = new Set(['ar']);
-
-function normalizeLanguage(lng: string): SupportedLanguage {
-  const base = (lng || 'en').split('-')[0]?.toLowerCase() || 'en';
-  if (SUPPORTED_LANGUAGE_SET.has(base as SupportedLanguage)) {
-    return base as SupportedLanguage;
-  }
-  return 'en';
-}
-
-function applyDocumentDirection(lang: string): void {
-  const base = lang.split('-')[0] || lang;
-  document.documentElement.setAttribute('lang', base === 'zh' ? 'zh-CN' : base);
-  if (RTL_LANGUAGES.has(base)) {
-    document.documentElement.setAttribute('dir', 'rtl');
-  } else {
-    document.documentElement.removeAttribute('dir');
-  }
-}
-
-async function ensureLanguageLoaded(lng: string): Promise<SupportedLanguage> {
-  const normalized = normalizeLanguage(lng);
-  if (loadedLanguages.has(normalized) && i18next.hasResourceBundle(normalized, 'translation')) {
-    return normalized;
-  }
-
-  let translation: TranslationDictionary;
-  if (normalized === 'en') {
-    translation = enTranslation as TranslationDictionary;
-  } else {
-    const loader = localeModules[`../locales/${normalized}.json`];
-    if (!loader) {
-      console.warn(`No locale file for "${normalized}", falling back to English`);
-      translation = enTranslation as TranslationDictionary;
-    } else {
-      translation = await loader();
-    }
-  }
-
-  i18next.addResourceBundle(normalized, 'translation', translation, true, true);
-  loadedLanguages.add(normalized);
-  return normalized;
-}
-
-// Initialize i18n
+/**
+ * Initialize i18n with forced English language.
+ * FR #183: Disable browser language auto-detection.
+ */
 export async function initI18n(): Promise<void> {
+  // Clear any previously cached language preference
+  localStorage.removeItem('i18nextLng');
+
   if (i18next.isInitialized) {
-    const currentLanguage = normalizeLanguage(i18next.language || 'en');
-    await ensureLanguageLoaded(currentLanguage);
-    applyDocumentDirection(i18next.language || currentLanguage);
+    document.documentElement.setAttribute('lang', FORCED_LANGUAGE);
     return;
   }
 
-  loadedLanguages.add('en');
+  await i18next.init({
+    resources: {
+      en: { translation: enTranslation as TranslationDictionary },
+    },
+    lng: FORCED_LANGUAGE, // Force English
+    supportedLngs: ['en'], // Only support English
+    fallbackLng: 'en',
+    debug: import.meta.env.DEV,
+    interpolation: {
+      escapeValue: false,
+    },
+  });
 
-  await i18next
-    .use(LanguageDetector)
-    .init({
-      resources: {
-        en: { translation: enTranslation as TranslationDictionary },
-      },
-      supportedLngs: [...SUPPORTED_LANGUAGES],
-      nonExplicitSupportedLngs: true,
-      fallbackLng: 'en',
-      debug: import.meta.env.DEV,
-      interpolation: {
-        escapeValue: false, // not needed for these simple strings
-      },
-      detection: {
-        order: ['localStorage', 'navigator'],
-        caches: ['localStorage'],
-      },
-    });
-
-  const detectedLanguage = await ensureLanguageLoaded(i18next.language || 'en');
-  if (detectedLanguage !== 'en') {
-    // Re-trigger translation resolution now that the detected bundle is loaded.
-    await i18next.changeLanguage(detectedLanguage);
-  }
-
-  applyDocumentDirection(i18next.language || detectedLanguage);
+  document.documentElement.setAttribute('lang', FORCED_LANGUAGE);
 }
 
 // Helper to translate
@@ -105,50 +45,27 @@ export function t(key: string, options?: Record<string, unknown>): string {
   return i18next.t(key, options);
 }
 
-// Helper to change language
-export async function changeLanguage(lng: string): Promise<void> {
-  const normalized = await ensureLanguageLoaded(lng);
-  await i18next.changeLanguage(normalized);
-  applyDocumentDirection(normalized);
-  window.location.reload(); // Simple reload to update all components for now
+// Helper to change language (no-op since we force English)
+export async function changeLanguage(_lng: string): Promise<void> {
+  // FR #183: Language switching is disabled, always use English
+  console.warn('Language switching is disabled. UI is forced to English.');
 }
 
-// Helper to get current language (normalized to short code)
+// Helper to get current language (always returns 'en')
 export function getCurrentLanguage(): string {
-  const lang = i18next.language || 'en';
-  return lang.split('-')[0]!;
+  return FORCED_LANGUAGE;
 }
 
+// RTL is disabled since we only support English
 export function isRTL(): boolean {
-  return RTL_LANGUAGES.has(getCurrentLanguage());
+  return false;
 }
 
 export function getLocale(): string {
-  const lang = getCurrentLanguage();
-  const map: Record<string, string> = { en: 'en-US', bg: 'bg-BG', cs: 'cs-CZ', el: 'el-GR', zh: 'zh-CN', pt: 'pt-BR', ja: 'ja-JP', ko: 'ko-KR', ro: 'ro-RO', tr: 'tr-TR', th: 'th-TH', vi: 'vi-VN' };
-  return map[lang] || lang;
+  return 'en-US';
 }
 
+// Keep LANGUAGES export for backward compatibility, but only English is active
 export const LANGUAGES = [
   { code: 'en', label: 'English', flag: '🇬🇧' },
-  { code: 'bg', label: 'Български', flag: '🇧🇬' },
-  { code: 'ar', label: 'العربية', flag: '🇸🇦' },
-  { code: 'cs', label: 'Čeština', flag: '🇨🇿' },
-  { code: 'zh', label: '中文', flag: '🇨🇳' },
-  { code: 'fr', label: 'Français', flag: '🇫🇷' },
-  { code: 'de', label: 'Deutsch', flag: '🇩🇪' },
-  { code: 'el', label: 'Ελληνικά', flag: '🇬🇷' },
-  { code: 'es', label: 'Español', flag: '🇪🇸' },
-  { code: 'it', label: 'Italiano', flag: '🇮🇹' },
-  { code: 'pl', label: 'Polski', flag: '🇵🇱' },
-  { code: 'pt', label: 'Português', flag: '🇵🇹' },
-  { code: 'nl', label: 'Nederlands', flag: '🇳🇱' },
-  { code: 'sv', label: 'Svenska', flag: '🇸🇪' },
-  { code: 'ru', label: 'Русский', flag: '🇷🇺' },
-  { code: 'ja', label: '日本語', flag: '🇯🇵' },
-  { code: 'ko', label: '한국어', flag: '🇰🇷' },
-  { code: 'ro', label: 'Română', flag: '🇷🇴' },
-  { code: 'th', label: 'ไทย', flag: '🇹🇭' },
-  { code: 'tr', label: 'Türkçe', flag: '🇹🇷' },
-  { code: 'vi', label: 'Tiếng Việt', flag: '🇻🇳' },
 ];


### PR DESCRIPTION
## Summary
Force UI to always display in English, regardless of browser language settings.

## Problem
i18n system was automatically detecting browser language, causing the UI to display in Chinese/French/Japanese etc. when users had those browser settings.

## Solution
Simplify `src/services/i18n.ts` to force English:

1. **Remove `i18next-browser-languagedetector`** dependency
2. **Force English**: Set `lng: 'en'` and `supportedLngs: ['en']`
3. **Clear cached preferences**: Remove `localStorage['i18nextLng']` on init
4. **Simplify helpers**:
   - `getCurrentLanguage()` → always returns `'en'`
   - `isRTL()` → always returns `false`
   - `getLocale()` → always returns `'en-US'`
   - `changeLanguage()` → logs warning, does nothing

## Changes
- `src/services/i18n.ts`: Simplified to force English
- `package.json`: Removed `i18next-browser-languagedetector`
- `package-lock.json`: Updated dependencies

## Testing
- ✅ typecheck passes
- ✅ unit tests pass (2280 tests)

## Verification
| Browser Language | UI (Before) | UI (After) |
|-----------------|------------|-----------|
| Chinese (zh-CN) | 中文界面 | English ✅ |
| French (fr-FR) | Interface française | English ✅ |
| Japanese (ja-JP) | 日本語 | English ✅ |
| English (en-US) | English | English ✅ |

Closes #183