### PR TITLE
fix(FR #189): display submarine cables as smooth Great Circle curves

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -24,8 +24,9 @@ import {
   type IrelandAICompany,
   type IrelandUniversity,
   type LandingStation,
-  type CableSegment,
+  type SubmarineCable,
 } from '@/config/variants/ireland/data';
+import { generateSmoothGreatCirclePath } from '@/utils/geo-smooth-path';
 import {
   getSemiconductorTier,
   getDataCenterTier,
@@ -78,7 +79,7 @@ import type { ClimateAnomaly } from '@/services/climate';
 import type { RadiationObservation } from '@/services/radiation';
 import { ArcLayer } from '@deck.gl/layers';
 import { HeatmapLayer } from '@deck.gl/aggregation-layers';
-import { H3HexagonLayer, GreatCircleLayer } from '@deck.gl/geo-layers';
+import { H3HexagonLayer } from '@deck.gl/geo-layers';
 import { PathStyleExtension } from '@deck.gl/extensions';
 import type { WeatherAlert } from '@/services/weather';
 import { escapeHtml } from '@/utils/sanitize';
@@ -2958,53 +2959,36 @@ export class DeckGLMap {
    * Color coded by destination: transatlantic(orange), UK(blue), Europe(green), planned(purple)
    */
   /**
-   * Create submarine cables layer using GreatCircleLayer (FR #176)
-   * Displays cables as curved arcs following Great Circle routes
-   * This is more accurate than straight lines for long-distance cables
+   * Create submarine cables layer using PathLayer with smooth Great Circle curves (FR #189)
+   * Generates smooth interpolated paths instead of segmented polylines
+   * Uses d3-geo interpolation for accurate Great Circle arcs
    */
-  private createSubmarineCablesLayer(): GreatCircleLayer<CableSegment> {
-    // Flatten cable paths into segments for GreatCircleLayer
-    // Each segment has source and target positions
-    const segments: CableSegment[] = [];
-    for (const cable of IRELAND_SUBMARINE_CABLES) {
-      const path = cable.path;
-      for (let i = 0; i < path.length - 1; i++) {
-        const source = path[i];
-        const target = path[i + 1];
-        if (source && target) {
-          segments.push({
-            cableId: cable.id,
-            source,
-            target,
-            destination: cable.destination,
-            status: cable.status,
-            cable, // Reference to original cable for popup
-          });
-        }
-      }
-    }
+  private createSubmarineCablesLayer(): PathLayer {
+    // Pre-generate smooth paths for each cable using Great Circle interpolation
+    // This creates a single continuous curve instead of segmented polylines
+    type CableWithPath = SubmarineCable & { smoothPath: [number, number][] };
+    const cablesWithSmoothPaths: CableWithPath[] = IRELAND_SUBMARINE_CABLES.map(cable => ({
+      ...cable,
+      smoothPath: generateSmoothGreatCirclePath(cable.path),
+    }));
 
-    return new GreatCircleLayer<CableSegment>({
+    return new PathLayer<CableWithPath>({
       id: 'submarine-cables-layer',
-      data: segments,
-      getSourcePosition: (d: CableSegment) => d.source,
-      getTargetPosition: (d: CableSegment) => d.target,
-      getSourceColor: (d: CableSegment) => {
+      data: cablesWithSmoothPaths,
+      // Use the pre-generated smooth path
+      getPath: (d) => d.smoothPath.map(([lng, lat]) => [lng, lat, 0] as [number, number, number]),
+      getColor: (d) => {
         const color = CABLE_COLORS[d.destination];
         const alpha = d.status === 'planned' || d.status === 'under-construction' ? 150 : 220;
         return [...color, alpha] as [number, number, number, number];
       },
-      getTargetColor: (d: CableSegment) => {
-        const color = CABLE_COLORS[d.destination];
-        const alpha = d.status === 'planned' || d.status === 'under-construction' ? 150 : 220;
-        return [...color, alpha] as [number, number, number, number];
-      },
-      getWidth: (d: CableSegment) => (d.status === 'active' ? 3 : 2),
+      getWidth: (d) => (d.status === 'active' ? 3 : 2),
       widthMinPixels: 2,
       widthMaxPixels: 6,
-      // Number of segments for smooth curve (more = smoother)
-      numSegments: 50,
       pickable: true,
+      // Smooth line caps and joints for better visual quality
+      capRounded: true,
+      jointRounded: true,
     });
   }
 
@@ -4253,10 +4237,7 @@ export class DeckGLMap {
       if (fullConflict) data = fullConflict;
     }
 
-    // For submarine cables, extract the original cable from CableSegment (FR #176)
-    if (popupType === 'submarineCable' && data.cable) {
-      data = data.cable;
-    }
+    // FR #189: SubmarineCable data is now used directly (no CableSegment extraction needed)
 
     // Enrich iran events with related events from same location
     if (popupType === 'iranEvent' && data.locationName) {

--- a/src/utils/geo-smooth-path.ts
+++ b/src/utils/geo-smooth-path.ts
@@ -1,0 +1,54 @@
+/**
+ * Generate smooth Great Circle paths for submarine cables
+ * FR #189: Fix cable display to show smooth curves instead of polylines
+ */
+import { geoInterpolate, geoDistance } from 'd3-geo';
+
+/**
+ * Generate a smooth Great Circle path between waypoints
+ * Uses d3-geo interpolation to create smooth curves
+ *
+ * @param waypoints - Array of [lng, lat] coordinates
+ * @param pointsPerKm - Sampling density (default: 1 point per 50km)
+ * @returns Array of interpolated [lng, lat] coordinates forming a smooth curve
+ */
+export function generateSmoothGreatCirclePath(
+  waypoints: [number, number][],
+  pointsPerKm = 1 / 50
+): [number, number][] {
+  if (waypoints.length < 2) return waypoints;
+
+  const allPoints: [number, number][] = [];
+
+  for (let i = 0; i < waypoints.length - 1; i++) {
+    const start = waypoints[i];
+    const end = waypoints[i + 1];
+
+    if (!start || !end) continue;
+
+    // Calculate distance in radians, convert to km (Earth radius ≈ 6371km)
+    const distanceRadians = geoDistance(start, end);
+    const distanceKm = distanceRadians * 6371;
+
+    // Determine number of interpolation points based on distance
+    // Minimum 20 points for short cables, scale up for longer ones
+    const numPoints = Math.max(20, Math.floor(distanceKm * pointsPerKm));
+
+    // D3 Great Circle interpolation
+    const interpolate = geoInterpolate(start, end);
+
+    // Generate intermediate points
+    for (let j = 0; j < numPoints; j++) {
+      const t = j / numPoints;
+      allPoints.push(interpolate(t) as [number, number]);
+    }
+  }
+
+  // Add final waypoint
+  const lastWaypoint = waypoints[waypoints.length - 1];
+  if (lastWaypoint) {
+    allPoints.push(lastWaypoint);
+  }
+
+  return allPoints;
+}

--- a/tests/geo-smooth-path.test.mts
+++ b/tests/geo-smooth-path.test.mts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateSmoothGreatCirclePath } from '../src/utils/geo-smooth-path.js';
+
+describe('generateSmoothGreatCirclePath', () => {
+  it('returns input unchanged for single point', () => {
+    const input: [number, number][] = [[-6.26, 53.35]];
+    const result = generateSmoothGreatCirclePath(input);
+    assert.deepEqual(result, input);
+  });
+
+  it('returns input unchanged for empty array', () => {
+    const result = generateSmoothGreatCirclePath([]);
+    assert.deepEqual(result, []);
+  });
+
+  it('generates interpolated points for two waypoints', () => {
+    // Dublin to London
+    const waypoints: [number, number][] = [
+      [-6.26, 53.35], // Dublin
+      [-0.13, 51.51], // London
+    ];
+    const result = generateSmoothGreatCirclePath(waypoints);
+
+    // Should have more points than input
+    assert.ok(result.length > 2, 'Should generate intermediate points');
+
+    // First and last points should be close to original waypoints
+    assert.ok(Math.abs(result[0]![0] - waypoints[0]![0]) < 0.01);
+    assert.ok(Math.abs(result[0]![1] - waypoints[0]![1]) < 0.01);
+    assert.ok(Math.abs(result[result.length - 1]![0] - waypoints[1]![0]) < 0.01);
+    assert.ok(Math.abs(result[result.length - 1]![1] - waypoints[1]![1]) < 0.01);
+  });
+
+  it('generates more points for longer distances', () => {
+    // Short distance: Dublin to London (~460km)
+    const shortWaypoints: [number, number][] = [
+      [-6.26, 53.35], // Dublin
+      [-0.13, 51.51], // London
+    ];
+    const shortResult = generateSmoothGreatCirclePath(shortWaypoints);
+
+    // Long distance: Dublin to New York (~5100km)
+    const longWaypoints: [number, number][] = [
+      [-6.26, 53.35], // Dublin
+      [-74.01, 40.71], // New York
+    ];
+    const longResult = generateSmoothGreatCirclePath(longWaypoints);
+
+    // Longer distance should generate more points
+    assert.ok(
+      longResult.length > shortResult.length,
+      `Long path (${longResult.length}) should have more points than short path (${shortResult.length})`
+    );
+  });
+
+  it('handles multi-waypoint paths (e.g., NY -> Halifax -> Dublin)', () => {
+    const waypoints: [number, number][] = [
+      [-74.01, 40.71], // New York
+      [-63.58, 44.65], // Halifax
+      [-6.26, 53.35], // Dublin
+    ];
+    const result = generateSmoothGreatCirclePath(waypoints);
+
+    // Should generate many points for this long route
+    assert.ok(result.length > 50, `Should have many points, got ${result.length}`);
+
+    // Last point should be Dublin
+    const lastPoint = result[result.length - 1]!;
+    assert.ok(Math.abs(lastPoint[0] - (-6.26)) < 0.01);
+    assert.ok(Math.abs(lastPoint[1] - 53.35) < 0.01);
+  });
+
+  it('generates points that follow Great Circle (northward arc for transatlantic)', () => {
+    // Dublin to New York - Great Circle should curve northward
+    const waypoints: [number, number][] = [
+      [-6.26, 53.35], // Dublin
+      [-74.01, 40.71], // New York
+    ];
+    const result = generateSmoothGreatCirclePath(waypoints);
+
+    // The midpoint should be north of the direct line
+    // Direct line midpoint latitude would be ~47
+    // Great Circle should go further north (around 52-55)
+    const midIndex = Math.floor(result.length / 2);
+    const midPoint = result[midIndex]!;
+
+    // Great Circle from Dublin to NYC curves north, so midpoint lat should be > 50
+    assert.ok(
+      midPoint[1] > 50,
+      `Midpoint latitude ${midPoint[1]} should be > 50 (Great Circle curves north)`
+    );
+  });
+
+  it('all generated points are valid coordinates', () => {
+    const waypoints: [number, number][] = [
+      [-6.26, 53.35], // Dublin
+      [-74.01, 40.71], // New York
+    ];
+    const result = generateSmoothGreatCirclePath(waypoints);
+
+    for (const [lng, lat] of result) {
+      assert.ok(lng >= -180 && lng <= 180, `Longitude ${lng} out of range`);
+      assert.ok(lat >= -90 && lat <= 90, `Latitude ${lat} out of range`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fix submarine cable display to show smooth Great Circle curves instead of polylines.

## Problem
The previous GreatCircleLayer implementation split multi-waypoint cables into segments. While each segment was curved, the joints between segments appeared as straight lines, creating a polyline effect.

**Example: Hibernia Express (NY → Halifax → Dublin → London)**
- Before: `～～～ ——— ～～～ ——— ～～～` (curved segments with straight joints)
- After: `～～～～～～～～～～～～～～～` (one continuous smooth curve)

## Solution
Replace `GreatCircleLayer` with `PathLayer` using pre-generated smooth paths:

1. **New `src/utils/geo-smooth-path.ts`**:
   - `generateSmoothGreatCirclePath(waypoints)` function
   - Uses d3-geo `geoInterpolate` for Great Circle interpolation
   - Samples every 50km (min 20 points) for smooth curves

2. **Modified `src/components/DeckGLMap.ts`**:
   - Switch from `GreatCircleLayer<CableSegment>` to `PathLayer`
   - Pre-generate smooth paths for each cable
   - Add `capRounded`/`jointRounded` for visual quality

## Changes
- `src/utils/geo-smooth-path.ts`: New smooth path generator
- `src/components/DeckGLMap.ts`: Use PathLayer with smooth paths
- `tests/geo-smooth-path.test.mts`: 7 unit tests

## Testing
- ✅ typecheck passes
- ✅ unit tests pass (2287 tests, including 7 new tests)

## Visual Comparison
| Aspect | Before | After |
|--------|--------|-------|
| Layer Type | GreatCircleLayer | PathLayer |
| Data Structure | CableSegment[] | SubmarineCable[] with smoothPath |
| Curve Quality | Segmented polyline | Continuous smooth curve |
| Transatlantic Arc | Visible but broken | Proper northward arc |

Closes #189