### PR TITLE
feat(FR #199): add map scale control for distance reference

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -772,6 +772,13 @@ export class DeckGLMap {
 
     this.maplibreMap.addControl(this.deckOverlay as unknown as maplibregl.IControl);
 
+    // FR #199: Add scale control for distance reference
+    const scaleControl = new maplibregl.ScaleControl({
+      maxWidth: 100,
+      unit: 'metric',
+    });
+    this.maplibreMap.addControl(scaleControl, 'bottom-left');
+
     this.maplibreMap.on('movestart', () => {
       if (this.moveTimeoutId) {
         clearTimeout(this.moveTimeoutId);


### PR DESCRIPTION
## Summary
Add a scale control to the map so users can estimate distances.

## Problem
- No way to judge distances on the map
- Can't estimate submarine cable lengths
- Hard to understand map scale at different zoom levels

## Solution
Add MapLibre GL's built-in `ScaleControl`:

```typescript
const scaleControl = new maplibregl.ScaleControl({
  maxWidth: 100,
  unit: 'metric',
});
this.maplibreMap.addControl(scaleControl, 'bottom-left');
```

## Configuration
| Option | Value | Reason |
|--------|-------|--------|
| Position | bottom-left | Avoids right-side panels |
| Unit | metric (km) | Standard in Ireland/Europe |
| Max Width | 100px | Reasonable size |

## Changes
- `src/components/DeckGLMap.ts`: Add ScaleControl after Deck overlay

## Testing
- ✅ typecheck passes
- ✅ unit tests pass (2295 tests)

## Visual Effect
The scale bar appears in the bottom-left corner and automatically updates when zooming/panning:
- Zoom out: Shows larger distances (e.g., 500 km)
- Zoom in: Shows smaller distances (e.g., 1 km)

Closes #199