### PR TITLE
feat(FR #220): Add 4 Irish tech news sources

### DIFF
--- a/src/config/variants/ireland.ts
+++ b/src/config/variants/ireland.ts
@@ -37,6 +37,11 @@ export const FEEDS: Record<string, Feed[]> = {
     { name: 'TheJournal.ie Tech (Google News)', url: rss('https://news.google.com/rss/search?q=site:thejournal.ie/tech+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
     { name: 'Business Post Tech (Google News)', url: rss('https://news.google.com/rss/search?q=site:businesspost.ie+technology+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
     { name: 'Irish Times Tech (Google News)', url: rss('https://news.google.com/rss/search?q=site:irishtimes.com+technology+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
+    // Additional Irish tech news sources (FR #220)
+    { name: 'TechCentral.ie (Google News)', url: rss('https://news.google.com/rss/search?q=site:techcentral.ie+(technology+OR+startup)+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
+    { name: 'TechBuzzIreland (Google News)', url: rss('https://news.google.com/rss/search?q=site:techbuzzireland.com+(technology+OR+tech+review)+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
+    { name: 'RTÉ Tech News (Google News)', url: rss('https://news.google.com/rss/search?q=site:rte.ie/news/technology+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
+    { name: 'Irish Tech News (Google News)', url: rss('https://news.google.com/rss/search?q=site:irishtechnews.ie+(technology+OR+startup)+when:2d&hl=en-IE&gl=IE&ceid=IE:en') },
     // AI Companies in Ireland (FR #178)
     { name: 'OpenAI Ireland', url: rss('https://news.google.com/rss/search?q=OpenAI+(Ireland+OR+Dublin)+when:14d&hl=en-IE&gl=IE&ceid=IE:en') },
     { name: 'Anthropic Ireland', url: rss('https://news.google.com/rss/search?q=Anthropic+(Ireland+OR+Dublin)+when:14d&hl=en-IE&gl=IE&ceid=IE:en') },


### PR DESCRIPTION
## Summary
Add 4 missing Irish tech news sources to the ieTech panel.

## New Sources
1. **TechCentral.ie** - Ireland's technology news resource
2. **TechBuzzIreland** - Real hands-on tech reviews and business news
3. **RTÉ Tech News** - National broadcaster tech section
4. **Irish Tech News** - Award-winning publication, Ireland's #1 online tech publication

## Changes
- Updated `src/config/variants/ireland.ts`
- Added 4 new Google News RSS feeds to `FEEDS.ieTech` array

Closes #220